### PR TITLE
Adapt to FairMQ v1.4.2+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,11 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-find_package(FairMQ REQUIRED)
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+find_package(FairMQ 1.4.2 REQUIRED)
 find_package(FairLogger ${FairMQ_FairLogger_VERSION} REQUIRED)
 
 # Boost

--- a/src/StfBuilder/SubTimeFrameBuilderInput.cxx
+++ b/src/StfBuilder/SubTimeFrameBuilderInput.cxx
@@ -15,7 +15,6 @@
 
 #include <O2Device/O2Device.h>
 #include <FairMQDevice.h>
-#include <fairmq/StateMachine.h>
 #include <FairMQLogger.h>
 
 #include <vector>

--- a/src/StfBuilder/SubTimeFrameBuilderInput.cxx
+++ b/src/StfBuilder/SubTimeFrameBuilderInput.cxx
@@ -15,7 +15,7 @@
 
 #include <O2Device/O2Device.h>
 #include <FairMQDevice.h>
-#include <FairMQStateMachine.h>
+#include <fairmq/StateMachine.h>
 #include <FairMQLogger.h>
 
 #include <vector>

--- a/src/TfBuilder/TimeFrameBuilderInput.cxx
+++ b/src/TfBuilder/TimeFrameBuilderInput.cxx
@@ -16,7 +16,6 @@
 
 #include <O2Device/O2Device.h>
 #include <FairMQDevice.h>
-#include <fairmq/StateMachine.h>
 #include <FairMQLogger.h>
 
 #include <condition_variable>

--- a/src/TfBuilder/TimeFrameBuilderInput.cxx
+++ b/src/TfBuilder/TimeFrameBuilderInput.cxx
@@ -16,7 +16,7 @@
 
 #include <O2Device/O2Device.h>
 #include <FairMQDevice.h>
-#include <FairMQStateMachine.h>
+#include <fairmq/StateMachine.h>
 #include <FairMQLogger.h>
 
 #include <condition_variable>

--- a/src/common/include/Utilities.h
+++ b/src/common/include/Utilities.h
@@ -30,10 +30,8 @@ class DataDistDevice : public Base::O2Device {
 
 public:
 
-  void WaitForRunningState() const {
-    while (GetCurrentState() < RUNNING) {
-      std::this_thread::yield();
-    }
+  void WaitForRunningState() {
+    WaitForState(fair::mq::State::Running);
   }
 };
 


### PR DESCRIPTION
These are the minimum changes needed to compile against FairMQ `v1.4.2+`. Readout also needs some changes, see AliceO2Group/Readout#38. aliBuild support for the `-DBUILD_OFI_TRANSPORT=ON` FairMQ build flag is proposed in alisw/alidist#1557. This PR is not backwards compatible, so consider it just for information.