### PR TITLE
Workaround for CC7 devtoolset7

### DIFF
--- a/src/StfSender/runSubTimeFrameSenderDevice.cxx
+++ b/src/StfSender/runSubTimeFrameSenderDevice.cxx
@@ -16,6 +16,7 @@
 #include <runFairMQDevice.h>
 
 namespace bpo = boost::program_options;
+template class std::basic_string<char, std::char_traits<char>, std::allocator<char> >; // Workaround for bug in CC7 devtoolset7
 
 void addCustomOptions(bpo::options_description& options)
 {


### PR DESCRIPTION
@ironMann : This seems to be needed to compile in our GPU CI, which uses CC7 with devtoolset7 (we cannot use our GCC-ToolChain due to the ROCm RPMs). There seems to be a bug in that compiler version, and the symbols are missing when the template is not instantiated explicitly.
Could you merge this and bump in alidist, preferably asap?

@ktf : With this and AliceO2Group/AliceO2#2968 the new GPU CI will become green.