### PR TITLE
cmake: stop linking against O2::Framework 

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(common
     base
     FairMQ::FairMQ
     AliceO2::Headers
-    AliceO2::Framework
 )
 
 


### PR DESCRIPTION
Attempt tot fix protobuf issue:

```
[libprotobuf ERROR /alice/sw/SOURCES/protobuf/v3.11.4/v3.11.4/src/google/protobuf/descriptor_database.cc:120] File already exists in database: discovery.proto 
[libprotobuf FATAL /alice/sw/SOURCES/protobuf/v3.11.4/v3.11.4/src/google/protobuf/descriptor.cc:1356] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
```

This removes other libraries linking against the grpc/protobuf.

AliceO2/pull/2934
O2-1194