### PR TITLE
Add fmt dependency (required by FairLogger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ endif()
 find_package(Threads REQUIRED)
 find_package(FairMQ 1.4 REQUIRED)
 find_package(FairLogger ${FairMQ_FairLogger_VERSION} REQUIRED)
+foreach(dep IN LISTS FairLogger_PACKAGE_DEPENDENCIES)
+find_package(${dep} ${FairLogger_${dep}_VERSION})
+endforeach()
 
 # Boost
 # Inherit FairMQ Boost deps and add ours


### PR DESCRIPTION
This is required by FairLogger. The intentionally do not find dependencies themselves in their CMakeTargets and do not pass them over as public interface library, so we have to add it ourselves.

@ironMann : Is this OK for you. Could you create a new tag with this.
I need this to bump FairLogger.