### PR TITLE
Enable all logs from FairLogger

### DIFF
--- a/src/common/base/DataDistLogger.h
+++ b/src/common/base/DataDistLogger.h
@@ -22,6 +22,7 @@
 #include <spdlog/async.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 
+#define FAIR_MIN_SEVERITY trace
 #include <fairlogger/Logger.h>
 
 


### PR DESCRIPTION
Enable all logs from FairLogger regardless of NDEBUG setting.