### PR TITLE
logging: allow {} as an input from FairMQ log. 

### DIFF
--- a/src/common/base/DataDistLogger.h
+++ b/src/common/base/DataDistLogger.h
@@ -78,7 +78,11 @@ private:
   static thread_local char* sThisThreadName;
 
   inline void do_vformat(fmt::string_view format, fmt::format_args args) {
-    fmt::vformat_to(mLogMessage, format, args);
+    try {
+      fmt::vformat_to(mLogMessage, format, args);
+    } catch (const fmt::format_error &e) {
+      fmt::format_to(mLogMessage, "FORMAT ERROR: {}. provided_format_string={}", e.what(), format);
+    }
   }
 
 public:
@@ -107,8 +111,8 @@ public:
   {}
 
   template<typename... Args>
-  DataDistLogger(const DataDistSeverity pSeverity, const log_fmq&, const std::string &format, const Args&... pArgs)
-  : DataDistLogger(pSeverity, log_fmt{}, ("[FMQ] " + format).c_str(), pArgs...)
+  DataDistLogger(const DataDistSeverity pSeverity, const log_fmq&, const std::string &pMsg)
+  : DataDistLogger(pSeverity, log_fmt{}, "[FMQ] {}", pMsg)
   {}
 
   template<class... Args>
@@ -269,8 +273,8 @@ private:
   if (DataDistLogger::LogEnabled(severity)) DataDistLogger(severity, DataDistLogger::log_fmt{}, __VA_ARGS__)
 
 // Log with fmt for FMQ messages
-#define DDLOGF_FMQ(severity, ...) \
-  if (DataDistLogger::LogEnabled(severity)) DataDistLogger(severity, DataDistLogger::log_fmq{}, __VA_ARGS__)
+#define DDLOGF_FMQ(severity, msg) \
+  if (DataDistLogger::LogEnabled(severity)) DataDistLogger(severity, DataDistLogger::log_fmq{}, msg)
 
 // Log with streams
 #define DDLOG(severity) \

--- a/src/tests/test_FmtPatterns.cxx
+++ b/src/tests/test_FmtPatterns.cxx
@@ -17,6 +17,7 @@
 #include <iostream>
 
 using namespace fmt;
+using namespace o2::DataDistribution;
 
 static const constexpr char* FmtSubSpec = "{:#06x}";
 
@@ -27,4 +28,9 @@ BOOST_AUTO_TEST_CASE(GetNextSeqNameTest)
   BOOST_CHECK("0x0000" == format(FmtSubSpec, 0)); // 32bit
   BOOST_CHECK("0xff00" == format(FmtSubSpec, 0xFF00)); // 32bit
   BOOST_CHECK("0x00ff" == format(FmtSubSpec, 0x00FF)); // 32bit
+
+
+  DataDistLogger(DataDistSeverity::info, DataDistLogger::log_fmq{}, std::string("{}"));
+
+  IDDLOG("Test {} {} {}", 1, 2);
 }


### PR DESCRIPTION
Otherwise, catch the format_error and log the incident