### PR TITLE
Apply DATADIST_SHM_DELAY only for the DataRegion, not for headers

### DIFF
--- a/src/common/MemoryUtils.h
+++ b/src/common/MemoryUtils.h
@@ -204,7 +204,7 @@ public:
 
     // Insert delay for testing
     const auto lShmDelay = std::getenv(ENV_SHM_DELAY);
-    if (lShmDelay) {
+    if (lShmDelay && mSegmentName.find("O2DataRegion") != std::string::npos) {
       try {
         double lDelaySec = std::stod(lShmDelay);
         lDelaySec = std::abs(lDelaySec);


### PR DESCRIPTION
So far the delay in `DATADIST_SHM_DELAY` was always applied twice when running the StfBuilder, when creating the Header Region and for the Data Region. With this PR we delay only once for the DataRegion. I think anyway noonce except for the full system test uses this feature, so it should be safe to change it in this way. I didn't want to introduce yet another option.