### PR TITLE
Fix broken compilation on Ubuntu 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ if(${CXX_GOOD_FLAGS})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wlogical-op -Wnull-dereference")
 endif()
 
+check_cxx_compiler_flag("-Wl,--no-as-needed -ldl" CXX_GOOD_FLAGS)
+if(${CXX_GOOD_FLAGS})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed -ldl")
+endif()
+
 check_cxx_compiler_flag("-Wduplicated-cond -Wdouble-promotion -Wshadow -Wformat=2" CXX_GOOD_FLAGS)
 if(${CXX_GOOD_FLAGS})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wduplicated-cond -Wdouble-promotion -Wshadow -Wformat=2")

--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -238,7 +238,10 @@ void StfSenderOutput::StfSchedulerThread()
 
   // increase the priority
 #if defined(__linux__)
-  nice(-10);
+  auto ignore_unused = [](auto /*param */) {
+
+  };
+  ignore_unused(nice(-10));
 #endif
 
   std::unique_ptr<SubTimeFrame> lStf;
@@ -408,7 +411,10 @@ void StfSenderOutput::DataHandlerThread(const std::string pTfBuilderId)
   DDDLOG("StfSenderOutput[{}]: Starting the thread", pTfBuilderId);
   // decrease the priority
 #if defined(__linux__)
-  nice(2);
+  auto ignore_unused = [](auto /*param */) {
+
+  };
+  ignore_unused(nice(2));
 #endif
 
   CoalescedHdrDataSerializer *lStfSerializer = nullptr;
@@ -481,7 +487,10 @@ void StfSenderOutput::StfDropThread()
   DDDLOG("Starting DataDropThread thread.");
   // decrease the priority
 #if defined(__linux__)
-  nice(5);
+  auto ignore_unused = [](auto /*param */) {
+
+  };
+  ignore_unused(nice(5));
 #endif
 
   std::uint64_t lNumDroppedStfs = 0;
@@ -517,7 +526,10 @@ void StfSenderOutput::StfMonitoringThread()
 
   // decrease the priority
 #if defined(__linux__)
-  nice(10);
+  auto ignore_unused = [](auto /*param */) {
+
+  };
+  ignore_unused(nice(10));
 #endif
 
   StdSenderOutputCounters lPrevCounters;

--- a/src/common/base/DataDistLogger.h
+++ b/src/common/base/DataDistLogger.h
@@ -345,6 +345,8 @@ struct DataDistLoggerCtx {
       EDDLOG("DataDistLoggerCtx: Already initialized! Static init was already done.");
       return;
     }
+    auto ignore_unused = [](auto /*param*/) {
+    };
 
     sRunning = true;
 
@@ -360,7 +362,7 @@ struct DataDistLoggerCtx {
 
     sRateUpdateThread = std::thread([&]() {
 #if defined(__linux__)
-      nice(+1);
+      ignore_unused(nice(+1));
       pthread_setname_np(pthread_self(), "log_clock");
 #endif
       while (sRunning) {
@@ -374,7 +376,7 @@ struct DataDistLoggerCtx {
     mInfoLoggerThread = std::thread([&]() {
       // nice the collection thread to decrease contention with sending threads
 #if defined(__linux__)
-      nice(+10);
+      ignore_unused(nice(+10));
       pthread_setname_np(pthread_self(), "infolog");
 #endif
 

--- a/src/common/monitoring/DataDistMonitoring.cxx
+++ b/src/common/monitoring/DataDistMonitoring.cxx
@@ -72,7 +72,10 @@ void DataDistMonitoring::MetricCollectionThread()
 
   // nice the collection thread to decrease contention with sending threads
 #if defined(__linux__)
-  nice(+10);
+  auto ignore_unused = [](auto /*param */) {
+
+  };
+  ignore_unused(nice(+10));
 #endif
 
   while (mRunning) {


### PR DESCRIPTION
- Add ignore_unused lambda ignoring return value
  of nice calls raising a warning for unused return value
  treated as error due to Werror
- Add compiler flag ldl if present