### PR TITLE
Use `<fairmq/FwdDecls.h>` instead of downstream forward declarations

### DIFF
--- a/src/ReadoutEmulator/CruMemoryHandler.h
+++ b/src/ReadoutEmulator/CruMemoryHandler.h
@@ -30,7 +30,7 @@
 
 #include <functional>
 
-class FairMQUnmanagedRegion;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::DataDistribution
 {

--- a/src/common/MemoryUtils.h
+++ b/src/common/MemoryUtils.h
@@ -44,7 +44,7 @@
 namespace icl = boost::icl;
 
 class DataHeader;
-class FairMQUnmanagedRegion;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::DataDistribution
 {

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -25,8 +25,7 @@
 #include <mutex>
 #include <optional>
 
-class FairMQDevice;
-class FairMQChannel;
+#include <fairmq/FwdDecls.h>
 
 namespace o2::DataDistribution
 {

--- a/src/common/SubTimeFrameVisitors.h
+++ b/src/common/SubTimeFrameVisitors.h
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-class FairMQChannel;
+#include <fairmq/FwdDecls.h>
 
 namespace o2
 {


### PR DESCRIPTION
This makes the forward declaration techniques more future-proof towards
renamed typenames in FairMQ, e.g. if forward declared types become a
type alias.

`<fairmq/FwdDecls.h>` is available since `FairMQ v1.4.39`.

---

* FairMQ bump is proposed in alisw/alidist#3168.
* For reference, see AliceO2Group/AliceO2#6657 and AliceO2Group/AliceO2#6658.