### PR TITLE
suppress warn_no_unused gcc bug

### DIFF
--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -238,7 +238,7 @@ void StfSenderOutput::StfSchedulerThread()
 
   // increase the priority
 #if defined(__linux__)
-  (void) nice(-10);
+  if (nice(-10)) {}
 #endif
 
   std::unique_ptr<SubTimeFrame> lStf;
@@ -408,7 +408,7 @@ void StfSenderOutput::DataHandlerThread(const std::string pTfBuilderId)
   DDDLOG("StfSenderOutput[{}]: Starting the thread", pTfBuilderId);
   // decrease the priority
 #if defined(__linux__)
-  (void) nice(2);
+  if (nice(2)) {}
 #endif
 
   CoalescedHdrDataSerializer *lStfSerializer = nullptr;
@@ -481,7 +481,7 @@ void StfSenderOutput::StfDropThread()
   DDDLOG("Starting DataDropThread thread.");
   // decrease the priority
 #if defined(__linux__)
-  (void) nice(5);
+  if (nice(5)) {}
 #endif
 
   std::uint64_t lNumDroppedStfs = 0;
@@ -517,7 +517,7 @@ void StfSenderOutput::StfMonitoringThread()
 
   // decrease the priority
 #if defined(__linux__)
-  (void) nice(10);
+  if (nice(10)) {}
 #endif
 
   StdSenderOutputCounters lPrevCounters;

--- a/src/common/base/DataDistLogger.h
+++ b/src/common/base/DataDistLogger.h
@@ -360,7 +360,7 @@ struct DataDistLoggerCtx {
 
     sRateUpdateThread = std::thread([&]() {
 #if defined(__linux__)
-      (void) nice(+1);
+      if (nice(+1)) {}
       pthread_setname_np(pthread_self(), "log_clock");
 #endif
       while (sRunning) {
@@ -374,7 +374,7 @@ struct DataDistLoggerCtx {
     mInfoLoggerThread = std::thread([&]() {
       // nice the collection thread to decrease contention with sending threads
 #if defined(__linux__)
-      (void) nice(+10);
+      if (nice(+10)) {}
       pthread_setname_np(pthread_self(), "infolog");
 #endif
 

--- a/src/common/monitoring/DataDistMonitoring.cxx
+++ b/src/common/monitoring/DataDistMonitoring.cxx
@@ -72,7 +72,7 @@ void DataDistMonitoring::MetricCollectionThread()
 
   // nice the collection thread to decrease contention with sending threads
 #if defined(__linux__)
-  (void) nice(+10);
+  if (nice(+10)) {}
 #endif
 
   while (mRunning) {


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425
