### PR TITLE
v1.0.3 pull

### DIFF
--- a/src/ReadoutEmulator/ReadoutDevice.h
+++ b/src/ReadoutEmulator/ReadoutDevice.h
@@ -80,8 +80,6 @@ class ReadoutDevice : public DataDistDevice
 
   /// Observables
   std::thread mInfoThread;
-
-  RunningSamples<uint64_t, 8192> mFreeSuperpagesSamples;
 };
 
 } /* namespace o2::DataDistribution */

--- a/src/StfBuilder/StfBuilderInput.cxx
+++ b/src/StfBuilder/StfBuilderInput.cxx
@@ -271,6 +271,7 @@ void StfInputInterface::StfBuilderThread()
             (*lStf)->header().mId, (*lStf)->getDataSize());
         }
 
+        (*lStf)->setOrigin(SubTimeFrame::Header::Origin::eReadout);
         mSeqStfQueue.push(std::move(*lStf));
         {
           auto lNow = hres_clock::now();
@@ -584,7 +585,6 @@ void StfInputInterface::StfSequencerThread()
     // have data, check the sequence
     if (lStf) {
       const auto lCurrId = (*lStf)->id();
-      (*lStf)->setOrigin(SubTimeFrame::Header::Origin::eReadout);
 
       if (lCurrId <= mLastSeqStfId) {
         EDDLOG_RL(500, "READOUT_INTERFACE: Repeated STF will be rejected. previous_stf_id={} current_stf_id={}",
@@ -610,7 +610,7 @@ void StfInputInterface::StfSequencerThread()
         // create the missing ones and continue
         for (std::uint64_t lStfIdIdx = lMissingIdStart; lStfIdIdx < lCurrId; lStfIdIdx++) {
           auto lEmptyStf = std::make_unique<SubTimeFrame>(lStfIdIdx);
-          (*lStf)->setOrigin(SubTimeFrame::Header::Origin::eNull);
+          lEmptyStf->setOrigin(SubTimeFrame::Header::Origin::eNull);
           mDevice.I().queue(eStfBuilderOut, std::move(lEmptyStf));
 
           lMissingStfs++;

--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -247,6 +247,9 @@ void StfSenderOutput::StfSchedulerThread()
     const auto lStfId = lStf->id();
     const auto lStfSize = lStf->getDataSize();
 
+    // remove split-payload headers
+    lStf->removeRedundantHeaders();
+
     // update buffer sizes
     StdSenderOutputCounters lCounters;
     {

--- a/src/TfBuilder/TfBuilderDevice.h
+++ b/src/TfBuilder/TfBuilderDevice.h
@@ -147,6 +147,8 @@ class TfBuilderDevice : public DataDistDevice,
 
   /// TF forwarding thread
   std::thread mTfFwdThread;
+  std::uint64_t mTfFwdTotalDataSize;
+  std::uint64_t mTfFwdTotalTfCount;
 
   std::atomic_bool mRunning = false;
   std::atomic_bool mShouldExit = false;

--- a/src/TfBuilder/TfBuilderInput.cxx
+++ b/src/TfBuilder/TfBuilderInput.cxx
@@ -70,11 +70,11 @@ bool TfBuilderInput::start(std::shared_ptr<ConsulTfBuilder> pConfig)
       lTransportFactory
     );
 
-    lNewChannel->Init();
-
     lNewChannel->UpdateRateLogging(1); // log each second
-
     lNewChannel->UpdateAutoBind(true); // make sure bind succeeds
+    lNewChannel->UpdateRcvBufSize(200); // make sure one sender does not advance too much
+    lNewChannel->UpdateRcvKernelSize(2 << 20);
+    lNewChannel->Init();
 
     if (!lNewChannel->BindEndpoint(lAddress)) {
       EDDLOG("Cannot bind channel to a free port! Check permissions. bind_address={}", lAddress);

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -41,13 +41,13 @@ class SubTimeFrameReadoutBuilder
   SubTimeFrameReadoutBuilder() = delete;
   SubTimeFrameReadoutBuilder(MemoryResources &pMemRes, bool pDplEnabled);
 
-  void addHbFrames(const o2::header::DataOrigin &pDataOrig,
+  bool addHbFrames(const o2::header::DataOrigin &pDataOrig,
     const o2::header::DataHeader::SubSpecificationType pSubSpecification,
     const ReadoutSubTimeframeHeader& pHdr,
     std::vector<FairMQMessagePtr>::iterator pHbFramesBegin, const std::size_t pHBFrameLen);
 
 
-  void addEquipmentData(const o2::header::DataOrigin &pDataOrig,
+  bool addEquipmentData(const o2::header::DataOrigin &pDataOrig,
     const o2::header::DataHeader::SubSpecificationType pSubSpecification,
     const ReadoutSubTimeframeHeader& pHdr,
     std::vector<FairMQMessagePtr>::iterator pHbFramesBegin, const std::size_t pHBFrameLen);
@@ -60,6 +60,7 @@ class SubTimeFrameReadoutBuilder
 
     std::unique_ptr<SubTimeFrame> lStf = std::move(mStf);
     mStf = nullptr;
+    mAcceptStfData = true;
     mFirstFiltered.clear();
 
     return (lStf) ? std::optional<std::unique_ptr<SubTimeFrame>>(std::move(lStf)) : std::nullopt;
@@ -74,6 +75,7 @@ class SubTimeFrameReadoutBuilder
   bool mRunning = true;
 
   std::unique_ptr<SubTimeFrame> mStf;
+  bool mAcceptStfData = true;        // toggle on allocation issues
 
   // filtering: keep info if the first HBFrame is already kept back
   std::unordered_map<o2::header::DataHeader::SubSpecificationType, bool> mFirstFiltered;

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -59,6 +59,12 @@ class SubTimeFrameReadoutBuilder
   std::optional<std::unique_ptr<SubTimeFrame>> getStf() {
 
     std::unique_ptr<SubTimeFrame> lStf = std::move(mStf);
+
+    // mark as NULL if data was rejected
+    if (lStf && !mAcceptStfData) {
+      lStf->setOrigin(SubTimeFrame::Header::Origin::eNull);
+    }
+
     mStf = nullptr;
     mAcceptStfData = true;
     mFirstFiltered.clear();

--- a/src/common/SubTimeFrameDataModel.cxx
+++ b/src/common/SubTimeFrameDataModel.cxx
@@ -141,4 +141,33 @@ void SubTimeFrame::mergeStf(std::unique_ptr<SubTimeFrame> pStf)
   pStf.reset();
 }
 
+void SubTimeFrame::removeRedundantHeaders()
+{
+  // Update data block indexes
+  for (auto &lIdentSubSpecVect : mData) {
+    StfSubSpecMap &lSubSpecMap = lIdentSubSpecVect.second;
+
+    for (auto &lSubSpecDataVector : lSubSpecMap) {
+      StfDataVector &lDataVector = lSubSpecDataVector.second;
+
+      // Only remove if RAWDATA
+      if (!lDataVector.empty() && lDataVector[0].mHeader) {
+        o2hdr::DataHeader *lDataHdr = reinterpret_cast<o2hdr::DataHeader*>(lDataVector[0].mHeader->GetData());
+        if (lDataHdr->dataDescription != gDataDescriptionRawData) {
+          continue;
+        }
+      }
+
+      // leave the first header
+      for (StfDataVector::size_type i = 1; i < lDataVector.size(); i++) {
+
+        if(lDataVector[i].mHeader) {
+
+          lDataVector[i].mHeader.reset(nullptr);
+        }
+      }
+    }
+  }
+}
+
 } /* o2::DataDistribution */

--- a/src/common/SubTimeFrameDataModel.h
+++ b/src/common/SubTimeFrameDataModel.h
@@ -327,7 +327,11 @@ class SubTimeFrame : public IDataModelObject
   const Header& header() const { return mHeader; }
   TimeFrameIdType id() const { return mHeader.mId; }
   Header::Origin origin() const { return mHeader.mOrigin; }
-  void setOrigin(const Header::Origin pOrig) { mHeader.mOrigin = pOrig; }
+  void setOrigin(const Header::Origin pOrig) {
+    if (mHeader.mOrigin == Header::Origin::eInvalid) {
+      mHeader.mOrigin = pOrig;
+    }
+  }
 
   void clear() { mData.clear(); mDataUpdated = false; }
   // NOTE: method declared const to work with const visitors, manipulated fields are mutable

--- a/src/common/SubTimeFrameFileWriter.cxx
+++ b/src/common/SubTimeFrameFileWriter.cxx
@@ -240,7 +240,9 @@ std::uint64_t SubTimeFrameFileWriter::_write(const SubTimeFrame& pStf)
 
     for (const auto& lStfData : mStfData) {
       // only write DataHeader (make a local DataHeader copy to clear flagsNextHeader bit)
-      DataHeader lDh = lStfData->getDataHeader();
+      const DataHeader *lDhPtr = lStfData->getDataHeader();
+      DataHeader lDh = (lDhPtr) ? *lDhPtr : DataHeader() ;
+
       lDh.flagsNextHeader = 0;
       buffered_write(reinterpret_cast<const char*>(&lDh), sizeof (DataHeader));
       buffered_write(lStfData->mData->GetData(), lStfData->mData->GetSize());
@@ -268,7 +270,7 @@ std::uint64_t SubTimeFrameFileWriter::_write(const SubTimeFrame& pStf)
       for (const auto& lStfData : mStfData) {
         fmt::memory_buffer lValRow;
 
-        const DataHeader &lDH = lStfData->getDataHeader();
+        const DataHeader &lDH = *lStfData->getDataHeader();
 
         const auto& l4DataOrigin = lDH.dataOrigin;
         const auto& l5DataDescription = lDH.dataDescription;

--- a/src/common/base/ConcurrentQueue.h
+++ b/src/common/base/ConcurrentQueue.h
@@ -374,8 +374,12 @@ class IFifoPipeline
   {
     T t;
     mPipelineQueues[pStage].pop(t);
-    mPipelinedSize--;
     return t;
+  }
+
+  std::optional<T> dequeue_for(const unsigned pStage, const std::chrono::microseconds &pWaitUs)
+  {
+    return mPipelineQueues[pStage].pop_wait_for(pWaitUs);
   }
 
   bool try_pop(unsigned pStage)
@@ -384,12 +388,9 @@ class IFifoPipeline
     return mPipelineQueues[pStage].try_pop(t);
   }
 
-  long getPipelineSize() const noexcept { return mPipelinedSize; }
-
  protected:
   virtual unsigned getNextPipelineStage(unsigned pStage) = 0;
 
-  std::atomic_long mPipelinedSize = 0;
   std::vector<o2::DataDistribution::ConcurrentFifo<T>> mPipelineQueues;
 };
 


### PR DESCRIPTION
- decrease the use of o2 headers when stfs are queued for transfer
- do not block in stfbuilder on shm allocation failure (back pressure)
- bugfix: properly mark null STFs so thay are not rejected by stfsender