### PR TITLE
stfs/tfb: fix [-Werror=deprecated-declarations]

### DIFF
--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -219,7 +219,7 @@ bool StfSenderOutput::disconnectTfBuilder(const std::string &pTfBuilderId, const
   }
   DDDLOG("StfSenderOutput::disconnectTfBuilder: Stopping sending channel. tfb_id={}", pTfBuilderId);
   if (lOutputObj.mChannel->IsValid() ) {
-    lOutputObj.mChannel->GetSocket().Close();
+    lOutputObj.mChannel.reset();
   }
 
   // update our connection status

--- a/src/TfBuilder/TfBuilderInput.cxx
+++ b/src/TfBuilder/TfBuilderInput.cxx
@@ -238,7 +238,6 @@ void TfBuilderInput::stop(std::shared_ptr<ConsulTfBuilder> pConfig)
       continue;
     }
     lFmqChannelPtr->GetSocket().SetLinger(0);
-    lFmqChannelPtr->GetSocket().Close();
   }
   mStfSenderChannels.clear();
   IDDLOG("TfBuilderInput::stop: All input channels are closed.");


### PR DESCRIPTION
```
src/StfSender/StfSenderOutput.cxx: In member function 'bool o2::DataDistribution::StfSenderOutput::disconnectTfBuilder(const string&, const string&)':
src/StfSender/StfSenderOutput.cxx:222:44: error: 'virtual void fair::mq::Socket::Close()' is deprecated: Use Socket::~Socket() instead. [-Werror=deprecated-declarations]
  222 |     lOutputObj.mChannel->GetSocket().Close();
      |                                            ^

src/TfBuilder/TfBuilderInput.cxx: In member function 'void o2::DataDistribution::TfBuilderInput::stop(std::shared_ptr<o2::DataDistribution::ConsulImpl::ConsulConfig<o2::DataDistribution::TfBuilderConfigStatus> >)':
src/TfBuilder/TfBuilderInput.cxx:241:39: error: 'virtual void fair::mq::Socket::Close()' is deprecated: Use Socket::~Socket() instead. [-Werror=deprecated-declarations]
  241 |     lFmqChannelPtr->GetSocket().Close();
      |                                       ^
```

untested, fix for alisw/alidist#3458