### PR TITLE
Support libfmt 8

### DIFF
--- a/cmake/CMakeLists.txt.in
+++ b/cmake/CMakeLists.txt.in
@@ -6,7 +6,7 @@ project(DataDistribution-3rdparties NONE)
 include(ExternalProject)
 ExternalProject_Add(spdlog
   GIT_REPOSITORY "https://github.com/gabime/spdlog.git"
-  GIT_TAG "v1.8.5"
+  GIT_TAG "v1.9.2"
 
   GIT_SHALLOW TRUE
   GIT_PROGRESS TRUE

--- a/src/common/base/DataDistLogger.h
+++ b/src/common/base/DataDistLogger.h
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 #include <fmt/core.h>
+#include <fmt/ostream.h>
 
 #include <spdlog/spdlog.h>
 #include <spdlog/async.h>


### PR DESCRIPTION
With these changes DD compiles with fmt 8.x.
However, there are a couple of deprecated warnings now. I am listing them below for reference. I think we should fix them as well in the long run.