### PR TITLE
Support for reusing shm regions

### DIFF
--- a/doc/StfBuilder.1
+++ b/doc/StfBuilder.1
@@ -226,10 +226,22 @@ deadlocks.
 .RS
 .RE
 .TP
+.B \f[B]\[en]data\-source\-region\-shmid\f[]
+Optional shm id for reusing existing TimeFrame regions.
+(default will create a new region)
+.RS
+.RE
+.TP
 .B \f[B]\[en]data\-source\-headersize\f[] arg (=512)
 Size of the memory region for (Sub)TimeFrames O2 headers in MiB.
 Note: make sure the region can fit several (Sub)TimeFrames to avoid
 deadlocks.
+.RS
+.RE
+.TP
+.B \f[B]\[en]data\-source\-header\-shmid\f[]
+Optional shm id for reusing existing TimeFrame header region.
+(default will create a new region)
 .RS
 .RE
 .TP

--- a/doc/StfBuilder.md
+++ b/doc/StfBuilder.md
@@ -155,9 +155,17 @@ to files, before they are sent out.
 :   Size of the memory region for (Sub)TimeFrames data in MiB. Note: make sure the
     region can fit several (Sub)TimeFrames to avoid deadlocks.
 
+**--data-source-region-shmid**
+:   Optional shm id for reusing existing TimeFrame regions.
+    (default will create a new region)
+
 **--data-source-headersize** arg (=512)
 :   Size of the memory region for (Sub)TimeFrames O2 headers in MiB. Note: make
     sure the region can fit several (Sub)TimeFrames to avoid deadlocks.
+
+**--data-source-header-shmid**
+:   Optional shm id for reusing existing TimeFrame header region.
+    (default will create a new region)
 
 **--data-source-file-list** arg
 :   File name which contains the list of files at remote location, e.g. a list of

--- a/script/start_Discovery-3FLP-3EPN.sh.in
+++ b/script/start_Discovery-3FLP-3EPN.sh.in
@@ -164,6 +164,8 @@ TF_BUILDER+=" --monitoring-interval=5.0"
 TF_BUILDER+=" --monitoring-log"
 TF_BUILDER+=" --stand-alone"
 
+TF_BUILDER+=" --shm-monitor=false"
+TF_BUILDER+=" --tf-data-region-size 2048"
 if [[ ! -z $TF_BUILDER_DPL_CHAN ]]; then
   TF_BUILDER+=" --dpl-channel-name=$TF_BUILDER_DPL_CHAN"
 fi

--- a/src/TfBuilder/TfBuilderDevice.h
+++ b/src/TfBuilder/TfBuilderDevice.h
@@ -56,8 +56,10 @@ class TfBuilderDevice : public DataDistDevice,
 {
  public:
   static constexpr const char* OptionKeyStandalone = "stand-alone";
-  static constexpr const char* OptionKeyTfMemorySize = "tf-memory-size";
-  static constexpr const char* OptionKeyTfHdrMemorySize = "tf-hdr-memory-size";
+  static constexpr const char* OptionKeyTfDataRegionSize = "tf-data-region-size";
+  static constexpr const char* OptionKeyTfDataRegionId = "tf-data-region-id";
+  static constexpr const char* OptionKeyTfHdrRegionSize = "tf-hdr-region-size";
+  static constexpr const char* OptionKeyTfHdrRegionId = "tf-hdr-region-Id";
   static constexpr const char* OptionKeyDplChannelName = "dpl-channel-name";
 
   /// Default constructor
@@ -126,8 +128,10 @@ class TfBuilderDevice : public DataDistDevice,
   /// Configuration
   std::string mDplChannelName;
   bool mStandalone;
-  std::uint64_t mTfBufferSize;
-  std::uint64_t mTfHdrBufferSize;
+  std::uint64_t mTfDataRegionSize;
+  std::optional<std::uint16_t> mTfDataRegionId = std::nullopt;
+  std::uint64_t mTfHdrRegionSize;
+  std::optional<std::uint16_t> mTfHdrRegionId = std::nullopt;
   std::string mPartitionId;
   bool mDplEnabled = false;
 

--- a/src/TfBuilder/TfBuilderDevice.h
+++ b/src/TfBuilder/TfBuilderDevice.h
@@ -59,7 +59,7 @@ class TfBuilderDevice : public DataDistDevice,
   static constexpr const char* OptionKeyTfDataRegionSize = "tf-data-region-size";
   static constexpr const char* OptionKeyTfDataRegionId = "tf-data-region-id";
   static constexpr const char* OptionKeyTfHdrRegionSize = "tf-hdr-region-size";
-  static constexpr const char* OptionKeyTfHdrRegionId = "tf-hdr-region-Id";
+  static constexpr const char* OptionKeyTfHdrRegionId = "tf-hdr-region-id";
   static constexpr const char* OptionKeyDplChannelName = "dpl-channel-name";
 
   /// Default constructor

--- a/src/TfBuilder/runTfBuilderDevice.cxx
+++ b/src/TfBuilder/runTfBuilderDevice.cxx
@@ -49,12 +49,18 @@ int main(int argc, char* argv[])
         o2::DataDistribution::TfBuilderDevice::OptionKeyStandalone,
         bpo::bool_switch()->default_value(false),
         "Standalone operation. TimeFrames will not be forwarded to other processes.")(
-        o2::DataDistribution::TfBuilderDevice::OptionKeyTfMemorySize,
+        o2::DataDistribution::TfBuilderDevice::OptionKeyTfDataRegionSize,
         bpo::value<std::uint64_t>()->default_value(1024),
-        "Memory buffer reserved for building and buffering TimeFrames (in MiB).")(
-        o2::DataDistribution::TfBuilderDevice::OptionKeyTfHdrMemorySize,
+        "Memory buffer (shm region) reserved for building and buffering TimeFrames (in MiB).")(
+        o2::DataDistribution::TfBuilderDevice::OptionKeyTfDataRegionId,
+        bpo::value<std::uint16_t>()->default_value(std::uint16_t(~0)),
+        "Optional shm id for reusing existing TimeFrame regions. (default will create a new region)")(
+        o2::DataDistribution::TfBuilderDevice::OptionKeyTfHdrRegionSize,
         bpo::value<std::uint64_t>()->default_value(512),
-        "Memory buffer reserved for TimeFrame O2 headers (in MiB).");
+        "Memory buffer (shm region) reserved for TimeFrame O2 headers (in MiB).")(
+        o2::DataDistribution::TfBuilderDevice::OptionKeyTfHdrRegionId,
+        bpo::value<std::uint16_t>()->default_value(std::uint16_t(~0)),
+        "Optional shm id for reusing existing TimeFrame header regions. (default will create a new region)");
 
       bpo::options_description lTfBuilderDplOptions("TfBuilder DPL options", 120);
       lTfBuilderDplOptions.add_options()(

--- a/src/common/SubTimeFrameBuilder.cxx
+++ b/src/common/SubTimeFrameBuilder.cxx
@@ -318,24 +318,26 @@ std::optional<std::unique_ptr<SubTimeFrame>> SubTimeFrameReadoutBuilder::addTopo
 ////////////////////////////////////////////////////////////////////////////////
 
 SubTimeFrameFileBuilder::SubTimeFrameFileBuilder(MemoryResources &pMemRes,
-  const std::size_t pDataSegSize, const std::size_t pHdrSegSize, bool pDplEnabled)
+  const std::size_t pDataSegSize, const std::optional<std::uint16_t> pDataSegId,
+  const std::size_t pHdrSegSize, const std::optional<std::uint16_t> pHdrSegId,
+  bool pDplEnabled)
   : mMemRes(pMemRes), mDplEnabled(pDplEnabled)
 {
+  mMemRes.mDataMemRes = std::make_unique<RegionAllocatorResource<>>(
+    "O2DataRegion_FileSource",
+    pDataSegId, pDataSegSize,
+    *mMemRes.mShmTransport,
+    RegionAllocStrategy::eFindLongest,
+    0 // TODO: GPU flags
+  );
+
   mMemRes.mHeaderMemRes = std::make_unique<RegionAllocatorResource<alignof(o2::header::DataHeader)>>(
     "O2HeadersRegion_FileSource",
-    std::nullopt, pHdrSegSize,
+    pHdrSegId, pHdrSegSize,
     *mMemRes.mShmTransport,
     RegionAllocStrategy::eFindFirst,
     0, /* GPU flags */
     false /* cannot fail */
-  );
-
-  mMemRes.mDataMemRes = std::make_unique<RegionAllocatorResource<>>(
-    "O2DataRegion_FileSource",
-    std::nullopt, pDataSegSize,
-    *mMemRes.mShmTransport,
-    RegionAllocStrategy::eFindLongest,
-    0 // TODO: GPU flags
   );
 
   mMemRes.start();

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -118,8 +118,10 @@ class SubTimeFrameFileBuilder
 {
  public:
   SubTimeFrameFileBuilder() = delete;
-  SubTimeFrameFileBuilder(MemoryResources &pMemRes, const std::size_t pDataSegSize,
-    const std::size_t pHdrSegSize, bool pDplEnabled);
+  SubTimeFrameFileBuilder(MemoryResources &pMemRes,
+    const std::size_t pDataSegSize, const std::optional<std::uint16_t> pDataSegId,
+    const std::size_t pHdrSegSize, const std::optional<std::uint16_t> pHdrSegId,
+    bool pDplEnabled);
 
   void adaptHeaders(SubTimeFrame *pStf);
 

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -175,7 +175,8 @@ class TimeFrameBuilder
   TimeFrameBuilder(SyncMemoryResources &pMemRes, bool pDplEnabled);
 
   // make allocate the memory here
-  void allocate_memory(const std::size_t pDataSegSize, const std::size_t pHdrSegSize);
+  void allocate_memory(const std::size_t pDataSegSize, const std::optional<std::uint16_t> pDataSegId,
+                       const std::size_t pHdrSegSize, const std::optional<std::uint16_t> pHdrSegId);
 
   void adaptHeaders(SubTimeFrame *pStf);
 

--- a/src/common/SubTimeFrameFileSource.h
+++ b/src/common/SubTimeFrameFileSource.h
@@ -100,7 +100,9 @@ class SubTimeFrameFileSource
   static constexpr const char* OptionKeyStfLoadPreRead = "data-source-preread";
   static constexpr const char* OptionKeyStfSourceRepeat = "data-source-repeat";
   static constexpr const char* OptionKeyStfSourceRegionSize = "data-source-regionsize";
+  static constexpr const char* OptionKeyStfSourceRegionId = "data-source-region-shmid";
   static constexpr const char* OptionKeyStfHeadersRegionSize = "data-source-headersize";
+  static constexpr const char* OptionKeyStfHeadersRegionId = "data-source-header-shmid";
 
   static constexpr const char* OptionKeyStfFileList = "data-source-file-list";
   static constexpr const char* OptionKeyStfCopyCmd = "data-source-copy-cmd";
@@ -163,7 +165,9 @@ class SubTimeFrameFileSource
   double mLoadRate = 1.f;
   std::uint32_t mPreReadStfs = 1;
   std::size_t mRegionSizeMB = 1024; /* 1GB in MiB */
+  std::optional<std::uint16_t> mTfDataRegionId = std::nullopt;
   std::size_t mHdrRegionSizeMB = 256;
+  std::optional<std::uint16_t> mTfHdrRegionId = std::nullopt;
 
   /// Thread for file writing
   std::atomic_bool mRunning = false;


### PR DESCRIPTION
To reuse existing shm regions, add the optional region ID parameter:

- StfBuilder (file source region): `--data-source-region-shmid` and `--data-source-header-shmid`

- TfBuilder: `--tf-data-region-id` and `--tf-hdr-region-id`
