### PR TITLE
Suppress ACO detector, add TST instead

### DIFF
--- a/doc/StfBuilder.1
+++ b/doc/StfBuilder.1
@@ -119,7 +119,7 @@ NOTE: Channel specification is given using
 .TP
 .B \f[B]\[en]detector\f[] name
 Specifies the detector string for SubTimeFrame building.
-Allowed are: ACO, CPV, CTP, EMC, FT0, FV0, FDD, HMP, ITS, MCH, MFT, MID,
+Allowed are: TST, CPV, CTP, EMC, FT0, FV0, FDD, HMP, ITS, MCH, MFT, MID,
 PHS, TOF, TPC, TRD, ZDC.
 .RS
 .RE

--- a/doc/StfBuilder.md
+++ b/doc/StfBuilder.md
@@ -89,7 +89,7 @@ to files, before they are sent out.
 ## SubTimeFrameBuilder data source
 
 **--detector** name
-:   Specifies the detector string for SubTimeFrame building. Allowed are: ACO, CPV,
+:   Specifies the detector string for SubTimeFrame building. Allowed are: TST, CPV,
     CTP, EMC, FT0, FV0, FDD, HMP, ITS, MCH, MFT, MID, PHS, TOF, TPC, TRD, ZDC.
 
 **--detector-rdh** ver

--- a/src/StfBuilder/StfBuilderDevice.cxx
+++ b/src/StfBuilder/StfBuilderDevice.cxx
@@ -518,7 +518,7 @@ bpo::options_description StfBuilderDevice::getDetectorProgramOptions() {
     OptionKeyStfDetector,
     bpo::value<std::string>()->default_value(""),
     "Specifies the detector string for SubTimeFrame building. Allowed are: "
-    "ACO, CPV, CTP, EMC, FT0, FV0, FDD, HMP, ITS, MCH, MFT, MID, PHS, TOF, TPC, TRD, ZDC."
+    "TST, CPV, CTP, EMC, FT0, FV0, FDD, HMP, ITS, MCH, MFT, MID, PHS, TOF, TPC, TRD, ZDC."
   )(
     OptionKeyRhdVer,
     bpo::value<ReadoutDataUtils::RdhVersion>()->default_value(ReadoutDataUtils::RdhVersion::eRdhInvalid, ""),
@@ -551,10 +551,7 @@ o2::header::DataOrigin StfBuilderDevice::getDataOriginFromOption(const std::stri
 {
   const auto lDetStr = boost::to_upper_copy<std::string>(pArg);
 
-  if (lDetStr == "ACO") {
-    return o2::header::gDataOriginACO;
-  }
-  else if (lDetStr == "CPV") {
+  if (lDetStr == "CPV") {
     return o2::header::gDataOriginCPV;
   }
   else if (lDetStr == "CTP") {


### PR DESCRIPTION
Hi @ironMann,
I've suppressed the non-existing ACO detector in O2 and added TST instead (on request of @knopers8).
This PR brings DD in agreement with O2.