### PR TITLE
DataDistribution v1.3.7

### DIFF
--- a/src/StfBuilder/StfBuilderDevice.cxx
+++ b/src/StfBuilder/StfBuilderDevice.cxx
@@ -99,6 +99,9 @@ void StfBuilderDevice::InitTask()
 
   // partition id
   I().mPartitionId = Config::getPartitionOption(*GetConfig()).value_or("");
+  if (I().mPartitionId.empty() && I().mStandalone) {
+    I().mPartitionId = "STAND-ALONE";
+  }
   if (I().mPartitionId.empty()) {
     EDDLOG("Partition id is not provided during InitTask(). Check command line or ECS parameters. Exiting.");
     ChangeState(fair::mq::Transition::ErrorFound);

--- a/src/common/SubTimeFrameDPL.cxx
+++ b/src/common/SubTimeFrameDPL.cxx
@@ -270,6 +270,8 @@ void StfToDplAdapter::sendEosToDpl()
     lDplExitHdr
   );
 
+  IDDLOG("Sending End of stream (EoS) message to {} receivers.", mChan.GetNumberOfConnectedPeers());
+
   // Send a multiparts
   for (auto lEosCnt = 0U; lEosCnt < mChan.GetNumberOfConnectedPeers(); lEosCnt++) {
     FairMQParts lCompletedMsg;

--- a/src/common/discovery/DataDistributionOptions.h
+++ b/src/common/discovery/DataDistributionOptions.h
@@ -56,7 +56,7 @@ static constexpr std::uint64_t StandaloneStfDeleteChanceDefault = 50;
 
 // Standalone: Amount of data to keep while running
 static constexpr std::string_view StandaloneStfDataBufferSizeMBKey = "StandaloneStfDataBufferSizeMB";
-static constexpr std::uint64_t StandaloneStfDataBufferSizeMBDefault = StfBufferSizeMBDefault;
+static constexpr std::uint64_t StandaloneStfDataBufferSizeMBDefault = 128;
 
 /// UCX transport
 // Allowed gap between two messages of the same region when creating RMA txgs

--- a/src/common/discovery/StfSenderRpcClient.h
+++ b/src/common/discovery/StfSenderRpcClient.h
@@ -133,7 +133,7 @@ public:
     }
 
     lNumStfSenders = lSchedulerInst.stf_sender_id_list().size();
-    DDDLOG("Connecting gRPC clients. stfs_id={}", lNumStfSenders);
+    DDDLOG("Connecting gRPC clients. stfs_num={}", lNumStfSenders);
 
     // Connect to all StfSenders
     for (const std::string &lStfSenderId : lSchedulerInst.stf_sender_id_list()) {


### PR DESCRIPTION
stfsender: decrease amount of used data bufers in standalone runs to 128MB
stfbuilder: do not require partition id in standalone runs
improve logging messages
consul: implement connection retries