### PR TITLE
DataDistribution v1.3.11

### DIFF
--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -517,8 +517,7 @@ void StfSenderOutput::StaleStfThread()
         break;
       }
 
-      WDDLOG_RL(10000, "StfStaleStfThread: Deleting an STF because it was not requested by any TfBuilder. stf_id={} stale_ms={}",
-        lStfInfo.mStf->id(),lStfTimeMs);
+      IDDLOG_RL(10000, "StfStaleStfThread: Deleting an stale STF. stf_id={} stale_ms={}", lStfInfo.mStf->id(),lStfTimeMs);
 
       mDropQueue.push(std::move(lStfInfo.mStf));
       mScheduledStfMap.erase(mScheduledStfMap.cbegin());

--- a/src/StfSender/StfSenderOutput.h
+++ b/src/StfSender/StfSenderOutput.h
@@ -19,6 +19,7 @@
 #include "StfSenderOutputUCX.h"
 
 #include <ConfigConsul.h>
+#include <DataDistributionOptions.h>
 
 #include <SubTimeFrameDataModel.h>
 #include <SubTimeFrameVisitors.h>
@@ -55,6 +56,7 @@ public:
   void StfSchedulerThread();
   void StfKeepThread();
   void StfDropThread();
+  void StaleStfThread();
   void StfMonitoringThread();
 
   /// RPC requests
@@ -96,6 +98,10 @@ public:
   /// Monitoring thread
   std::thread mMonitoringThread;
 
+  /// Stale STF thread
+  std::thread mStaleStfThread;
+  std::uint64_t mStaleStfTimeoutMs = StaleStfTimeoutMsDefault;
+
   /// Stf keeper thread for standalone runs
   std::atomic_uint64_t mKeepTarget = 512ULL << 20;
   std::atomic_uint64_t mDeletePercentage = 50;
@@ -111,7 +117,7 @@ public:
   std::thread mSchedulerThread;
   std::uint64_t mLastStfId = 0;
   std::mutex mScheduledStfMapLock;
-    std::map<std::uint64_t, std::unique_ptr<SubTimeFrame>> mScheduledStfMap;
+    std::map<std::uint64_t, ScheduledStfInfo> mScheduledStfMap;
 
   /// Buffer utilization counters
   StdSenderOutputCounters mCounters;

--- a/src/StfSender/StfSenderOutputDefs.h
+++ b/src/StfSender/StfSenderOutputDefs.h
@@ -15,10 +15,13 @@
 #define STF_SENDER_OUTPUT_DEFS_H_
 
 #include <mutex>
-
+#include <chrono>
+#include <memory>
 
 namespace o2::DataDistribution
 {
+
+class SubTimeFrame;
 
 enum ConnectStatus { eOK, eEXISTS, eCONNERR };
 
@@ -45,6 +48,12 @@ struct StdSenderOutputCounters {
       std::uint32_t mMissing = 0;
     } mTotalSent;
   } mValues;
+};
+
+struct ScheduledStfInfo {
+  std::unique_ptr<SubTimeFrame>         mStf;
+  std::chrono::steady_clock::time_point mTimeAdded;
+  std::chrono::steady_clock::time_point mTimeRequested;
 };
 
 } /* namespace o2::DataDistribution */

--- a/src/StfSender/StfSenderOutputUCX.cxx
+++ b/src/StfSender/StfSenderOutputUCX.cxx
@@ -193,9 +193,9 @@ bool StfSenderOutputUCX::disconnectTfBuilder(const std::string &pTfBuilderId)
   return true;
 }
 
-bool StfSenderOutputUCX::sendStfToTfBuilder(const std::string &pTfBuilderId, std::unique_ptr<SubTimeFrame> &&pStf)
+bool StfSenderOutputUCX::sendStfToTfBuilder(const std::string &pTfBuilderId, ScheduledStfInfo &&pStfInfo)
 {
-  mSendRequestQueue.push(SendStfInfo{std::move(pStf), pTfBuilderId});
+  mSendRequestQueue.push(SendStfInfo{std::move(pStfInfo.mStf), pTfBuilderId});
   return true;
 }
 

--- a/src/StfSender/StfSenderOutputUCX.h
+++ b/src/StfSender/StfSenderOutputUCX.h
@@ -75,7 +75,7 @@ public:
   ConnectStatus connectTfBuilder(const std::string &pTfBuilderId, const std::string &lTfBuilderIp, const unsigned lTfBuilderPort);
   bool disconnectTfBuilder(const std::string &pTfBuilderId);
 
-  bool sendStfToTfBuilder(const std::string &pTfBuilderId, std::unique_ptr<SubTimeFrame> &&pStf);
+  bool sendStfToTfBuilder(const std::string &pTfBuilderId, ScheduledStfInfo &&pStfInfo);
 
   void DataHandlerThread(unsigned pThreadIdx);
   void StfDeallocThread();

--- a/src/TfBuilder/TfBuilderInputFairMQ.cxx
+++ b/src/TfBuilder/TfBuilderInputFairMQ.cxx
@@ -124,7 +124,7 @@ bool TfBuilderInputFairMQ::start(std::shared_ptr<ConsulTfBuilder> pConfig, std::
   // Connect all StfSenders
   TfBuilderConnectionResponse lConnResult;
   do {
-    IDDLOG("Requesting StfSender connections from the TfScheduler.");
+    IDDLOG_RL(5000, "Requesting StfSender connections from the TfScheduler.");
 
     lConnResult.Clear();
     if (!mRpc->TfSchedRpcCli().TfBuilderConnectionRequest(lStatus, lConnResult)) {

--- a/src/TfBuilder/TfBuilderInputUCX.cxx
+++ b/src/TfBuilder/TfBuilderInputUCX.cxx
@@ -210,7 +210,7 @@ bool TfBuilderInputUCX::start()
   // Connect all StfSenders
   TfBuilderUCXConnectionResponse lConnResult;
   do {
-    IDDLOG("Requesting StfSender connections from the TfScheduler.");
+    IDDLOG_RL(5000, "Requesting StfSender connections from the TfScheduler.");
 
     lConnResult.Clear();
     if (!mRpc->TfSchedRpcCli().TfBuilderUCXConnectionRequest(lConfStatus, lConnResult)) {

--- a/src/TfBuilder/TfBuilderRpc.cxx
+++ b/src/TfBuilder/TfBuilderRpc.cxx
@@ -172,8 +172,14 @@ void TfBuilderRpcImpl::UpdateConsulParams()
 // make sure these are sent immediately
 void TfBuilderRpcImpl::startAcceptingTfs() {
   std::unique_lock lLock(mUpdateLock);
-  mAcceptingTfs = true;
-  sendTfBuilderUpdate();
+
+  if (getNumFailedRpcConnections() == 0) {
+    mAcceptingTfs = true;
+    sendTfBuilderUpdate();
+  } else {
+    EDDLOG_RL(10000, "TfBuilderRpc::Not enabling TfBuilder because some gRPC connections are not working. failed_cnt={}",
+      getNumFailedRpcConnections());
+  }
 }
 
 void TfBuilderRpcImpl::stopAcceptingTfs() {

--- a/src/TfBuilder/TfBuilderRpc.h
+++ b/src/TfBuilder/TfBuilderRpc.h
@@ -63,6 +63,10 @@ public:
     std::shared_ptr<ConcurrentQueue<ReceivedStfMeta> > pRecvQueue);
   void stop();
 
+  unsigned getNumFailedRpcConnections() const {
+    return (mStfSenderRpcClients.getNumConnectedClients() - mStfSenderRpcClients.getNumWorkingClients());
+  }
+
   void startAcceptingTfs();
   void stopAcceptingTfs();
 

--- a/src/TfScheduler/TfSchedulerConnManager.h
+++ b/src/TfScheduler/TfSchedulerConnManager.h
@@ -134,6 +134,11 @@ class TfSchedulerConnManager
     return mStfSenderRpcClients.size();
   }
 
+  void setMonitorDuration(const bool pMon) {
+    mStfSenderRpcClients.setMonitorDuration(pMon);
+    mTfBuilderRpcClients.setMonitorDuration(pMon);
+  }
+
 private:
   /// Partition information
   PartitionRequest mPartitionInfo;

--- a/src/TfScheduler/TfSchedulerInstanceRpc.cxx
+++ b/src/TfScheduler/TfSchedulerInstanceRpc.cxx
@@ -112,6 +112,8 @@ void TfSchedulerInstanceRpcImpl::updatePartitionState(const PartitionState pNewS
 
 void TfSchedulerInstanceRpcImpl::PartitionMonitorThread()
 {
+  DDDLOG("PartitionMonitorThread: Starting.");
+
   while (mRunning) {
     std::this_thread::sleep_for(500ms);
 

--- a/src/TfScheduler/TfSchedulerInstanceRpc.cxx
+++ b/src/TfScheduler/TfSchedulerInstanceRpc.cxx
@@ -114,8 +114,17 @@ void TfSchedulerInstanceRpcImpl::PartitionMonitorThread()
 {
   DDDLOG("PartitionMonitorThread: Starting.");
 
+  bool lMonitorRpcDurationPrev = DataDistMonitorRpcDurationDefault;
+
   while (mRunning) {
     std::this_thread::sleep_for(500ms);
+
+    auto lMonitorRpcDurationNew = mDiscoveryConfig->getBoolParam(DataDistMonitorRpcDurationKey, DataDistMonitorRpcDurationDefault);
+    if (lMonitorRpcDurationPrev != lMonitorRpcDurationNew) {
+      IDDLOG("DataDistMonitorRpcDuration changed. new={} old={}", lMonitorRpcDurationNew, lMonitorRpcDurationPrev);
+      lMonitorRpcDurationPrev = lMonitorRpcDurationNew;
+      mConnManager.setMonitorDuration(lMonitorRpcDurationNew);
+    }
 
     // In teardown?
     if (mPartitionState == PartitionState::PARTITION_TERMINATING

--- a/src/TfScheduler/TfSchedulerStfInfo.cxx
+++ b/src/TfScheduler/TfSchedulerStfInfo.cxx
@@ -170,10 +170,10 @@ void TfSchedulerStfInfo::StaleCleanupThread()
   std::vector<StfInfo> lStfInfos;
 
   // update housekeeping parameters
-  auto lStaleStfTimeoutMs = std::clamp(mDiscoveryConfig->getUInt64Param(StaleStfTimeoutMsKey, StaleStfTimeoutMsValue),
+  auto lStaleStfTimeoutMs = std::clamp(mDiscoveryConfig->getUInt64Param(StaleTfTimeoutMsKey, StaleTfTimeoutMsDefault),
       std::uint64_t(250), std::uint64_t(60000));
 
-  IDDLOG("StaleCleanupThread: parameter (consul) {}={}", StaleStfTimeoutMsKey, lStaleStfTimeoutMs);
+  IDDLOG("StaleCleanupThread: parameter (consul) {}={}", StaleTfTimeoutMsKey, lStaleStfTimeoutMs);
 
   while (mRunning) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -181,7 +181,7 @@ void TfSchedulerStfInfo::StaleCleanupThread()
 
     lStaleStfsToComplete.clear();
     // update housekeeping parameters
-    lStaleStfTimeoutMs = std::clamp(mDiscoveryConfig->getUInt64Param(StaleStfTimeoutMsKey, StaleStfTimeoutMsValue),
+    lStaleStfTimeoutMs = std::clamp(mDiscoveryConfig->getUInt64Param(StaleStfTimeoutMsKey, StaleStfTimeoutMsDefault),
       std::uint64_t(250), std::uint64_t(60000));
     {
       std::unique_lock lLock(mGlobalStfInfoLock);

--- a/src/TfScheduler/TfSchedulerStfInfo.cxx
+++ b/src/TfScheduler/TfSchedulerStfInfo.cxx
@@ -80,6 +80,15 @@ void TfSchedulerStfInfo::SchedulingThread()
       lTfSize += lStfI.stf_size();
       (*lRequest.mutable_stf_size_map())[lStfI.process_id()] = lStfI.stf_size();
     }
+
+    // check for TF size. Discard zero-length TFs that have no detector data
+    if (lTfSize == 0) {
+      mZeroTfsCount += 1;
+      DDMON("tfscheduler", "tf.rejected.zero", mZeroTfsCount);
+      requestDropAllFromSchedule(lTfId, 0); // do not decrement rejected tf counter
+      continue;
+    }
+
     lRequest.set_tf_id(lTfId);
     lRequest.set_tf_size(lTfSize);
     lRequest.set_tf_source(StfSource::DEFAULT);

--- a/src/TfScheduler/TfSchedulerStfInfo.h
+++ b/src/TfScheduler/TfSchedulerStfInfo.h
@@ -179,6 +179,7 @@ private:
     std::uint64_t mLastStfId = 0;
     std::uint64_t mMaxCompletedTfId = 0;
     std::uint64_t mNotScheduledTfsCount = 0;
+    std::uint64_t mZeroTfsCount = 0;
     std::uint64_t mStaleTfCount = 0;
     std::uint64_t mScheduledTfs = 0;
     EventRecorder mDroppedStfs;
@@ -189,6 +190,7 @@ private:
       mLastStfId = 0;
       mMaxCompletedTfId = 0;
       mNotScheduledTfsCount = 0;
+      mZeroTfsCount = 0;
       mStaleTfCount = 0;
       mScheduledTfs = 0;
       mDroppedStfs.reset();
@@ -208,7 +210,7 @@ private:
       mNotScheduledTfsCount++;
     }
 
-  inline void requestDropAllFromSchedule(const std::uint64_t lStfId) {
+  inline void requestDropAllFromSchedule(const std::uint64_t lStfId, const std::uint64_t pInc = 1) {
     std::scoped_lock lLock(mGlobalStfInfoLock);
     if (mDroppedStfs.GetEvent(lStfId) != false) {
       EDDLOG_RL(1000, "Request for dripping of already discarded TF. tf_id={}", lStfId);
@@ -216,7 +218,7 @@ private:
     mDroppedStfs.SetEvent(lStfId);
     mStfInfoMap.erase(lStfId);
     mDropQueue.push(std::make_tuple(lStfId, ""));
-    mNotScheduledTfsCount++;
+    mNotScheduledTfsCount += pInc;
   }
 
   inline void requestDropTopoStf(const std::uint64_t lStfId, const std::string &pStfsId) {

--- a/src/common/discovery/DataDistributionOptions.h
+++ b/src/common/discovery/DataDistributionOptions.h
@@ -54,6 +54,10 @@ static constexpr bool StartTopologicalStfOnNewOrbitDefault = true;
 static constexpr std::string_view StfBufferSizeMBKey = "StfBufferSizeMB";
 static constexpr std::uint64_t StfBufferSizeMBDefault = (32ULL << 10);
 
+// Time to wait until an STF is claimed by a TfBuilder
+static constexpr std::string_view StaleStfTimeoutMsKey = "StaleStfTimeoutMs";
+static constexpr std::uint64_t StaleStfTimeoutMsDefault = 60000;
+
 // Standalone: Chance the stf will be deleted on arrival
 static constexpr std::string_view StandaloneStfDeleteChanceKey = "StandaloneStfDeleteChance";
 static constexpr std::uint64_t StandaloneStfDeleteChanceDefault = 50;
@@ -109,8 +113,8 @@ static constexpr std::string_view BuildIncompleteTfsKey = "BuildIncompleteTfs";
 static constexpr bool BuildIncompleteTfsValue = true;
 
 // An incomplete TF is considered stale when the following timeout expires after the last STF is reported.
-static constexpr std::string_view StaleStfTimeoutMsKey = "StaleTfTimeoutMs";
-static constexpr std::uint64_t StaleStfTimeoutMsValue = 1000;
+static constexpr std::string_view StaleTfTimeoutMsKey = "StaleTfTimeoutMs";
+static constexpr std::uint64_t StaleTfTimeoutMsDefault = 1000;
 
 // Max number of incomplete TFs to keep before considering them stale
 static constexpr std::string_view IncompleteTfsMaxCntKey = "IncompleteTfsMaxCnt";

--- a/src/common/rpc/StfSenderRpcClient.cxx
+++ b/src/common/rpc/StfSenderRpcClient.cxx
@@ -23,7 +23,10 @@ StfSenderRpcClient::StfSenderRpcClient(const std::string &pEndpoint)
 {
   mChannel = grpc::CreateChannel(pEndpoint, grpc::InsecureChannelCredentials());
   mStub = StfSenderRpc::NewStub(mChannel);
+
+  // trigger faster connection
   mChannel->GetState(true);
+  mChannel->WaitForConnected(gpr_now(GPR_CLOCK_MONOTONIC));
 }
 
 bool StfSenderRpcClient::is_ready() const {

--- a/src/common/rpc/StfSenderRpcClient.h
+++ b/src/common/rpc/StfSenderRpcClient.h
@@ -196,6 +196,8 @@ public:
         lStfSenderId,
         std::make_unique<StfSenderRpcClient>(lStfSenderStatus.rpc_endpoint())
       );
+
+      mClients[lStfSenderId]->setMonitorDuration(mMonitorRpcDuration);
     }
 
     // make sure all connections are established
@@ -270,10 +272,11 @@ public:
   bool started() const { return (mRunning && mClientsCreated); }
 
   void setMonitorDuration(const bool pMon) {
+    mMonitorRpcDuration = pMon;
     std::shared_lock lLock(mClientsGlobalLock);
     for (auto &[ mCliId, lClient] : mClients) {
       (void) mCliId;
-      lClient->setMonitorDuration(pMon);
+      lClient->setMonitorDuration(mMonitorRpcDuration);
     }
   }
 
@@ -285,6 +288,9 @@ private:
   bool mClientsCreated = false;
   std::shared_mutex mClientsGlobalLock;
   std::map<std::string, std::unique_ptr<StfSenderRpcClient>> mClients;
+
+  // monitoring
+  bool mMonitorRpcDuration = false;
 };
 
 } /* namespace o2::DataDistribution */

--- a/src/common/rpc/TfBuilderRpcClient.h
+++ b/src/common/rpc/TfBuilderRpcClient.h
@@ -59,7 +59,11 @@ public:
 
     mChannel = grpc::CreateChannel(lEndpoint, grpc::InsecureChannelCredentials());
     mStub = TfBuilderRpc::NewStub(mChannel);
+
+    // speed up connecting
     mChannel->GetState(true);
+    mChannel->WaitForConnected(gpr_now(GPR_CLOCK_MONOTONIC));
+
     mRunning = true;
 
     if (is_alive()) {

--- a/src/common/rpc/TfSchedulerRpcClient.h
+++ b/src/common/rpc/TfSchedulerRpcClient.h
@@ -72,7 +72,10 @@ public:
 
     mChannel = grpc::CreateChannel(lEndpoint, grpc::InsecureChannelCredentials());
     mStub = TfSchedulerInstanceRpc::NewStub(mChannel);
+
+    // speed up connection
     mChannel->GetState(true);
+    mChannel->WaitForConnected(gpr_now(GPR_CLOCK_MONOTONIC));
 
     IDDLOG("Connected to TfScheduler RPC endpoint={}", lEndpoint);
 


### PR DESCRIPTION
- grpc: speed up connection establishing
- tfscheduler: stop propagating tfs with no detector data to epn
- tfscheduler: monitor rpc duration (optional)
- stfsender: remove unclaimed stfs after a timeout (EPN-49)
- tfbuilder: prevent activating TfBuilder if grpc::StfDataRequest() cannot be made in InitTask() (EPN-49)