### PR TITLE
DataDistribution v1.3.12

### DIFF
--- a/src/StfBuilder/StfBuilderInput.h
+++ b/src/StfBuilder/StfBuilderInput.h
@@ -14,6 +14,7 @@
 #ifndef ALICEO2_STFBUILDER_INPUT_H_
 #define ALICEO2_STFBUILDER_INPUT_H_
 
+#include <DataDistMonitoring.h>
 #include <SubTimeFrameBuilder.h>
 #include <ConcurrentQueue.h>
 #include <Utilities.h>
@@ -48,9 +49,12 @@ public:
       mStfIdReceiving = 0;
       mStfIdBuilding = 0;
       mLastSeqStfId = 0;
+      mMissingStfs = 0;
     }
 
     mAcceptingData = pRunning;
+
+    DDMON("stfbuilder", "stf_input.missing_stf.total", 0);
   }
 
   void StfReceiverThread();
@@ -79,9 +83,11 @@ public:
   std::thread mBuilderThread;
 
   /// StfSequencer thread
+  std::thread mStfSeqThread;
   ConcurrentFifo<std::unique_ptr<SubTimeFrame>> mSeqStfQueue;
   std::uint64_t mLastSeqStfId = 0;
-  std::thread mStfSeqThread;
+  std::uint64_t mMissingStfs = 0;
+
 };
 
 } /* namespace o2::DataDistribution */

--- a/src/StfSender/StfSenderDevice.cxx
+++ b/src/StfSender/StfSenderDevice.cxx
@@ -149,10 +149,10 @@ void StfSenderDevice::InitTask()
 
       // contact the scheduler on gRPC
       while (I().mTfSchedulerRpcClient.should_retry_start() && !I().mTfSchedulerRpcClient.start(I().mDiscoveryConfig)) {
-        std::this_thread::sleep_for(100ms * (rand()%5 + 1));
+        std::this_thread::sleep_for(150ms);
       }
 
-      // We failed to connect to the TfScheduler
+      // Did we failed to connect to the TfScheduler?
       if (!I().mTfSchedulerRpcClient.should_retry_start()) {
         EDDLOG("InitTask: Failed to connect to TfScheduler. Exiting.");
         ChangeState(fair::mq::Transition::ErrorFound);

--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -336,11 +336,6 @@ void StfSenderOutput::StfSchedulerThread()
         lInfoPtr->set_data_subspec(lStfEquip.begin()->mSubSpecification);
         break;
       }
-      case SubTimeFrame::Header::Origin::eNull:
-      {
-        lStfInfo.set_stf_source(StfSource::EMPTY);
-        break;
-      }
       default:
       {
         EDDLOG_RL(1000, "StfSchedulerThread: dropping STF of unknown type stf_source={}", lStf->header().mOrigin);

--- a/src/TfScheduler/TfSchedulerStfInfo.cxx
+++ b/src/TfScheduler/TfSchedulerStfInfo.cxx
@@ -126,12 +126,15 @@ void TfSchedulerStfInfo::SchedulingThread()
               break;
           }
         } else {
-          EDDLOG("Scheduling of Tf failed. to_tfb_id={} reason=grpc_error", lTfBuilderId);
-          EDDLOG("Removing TfBuilder from scheduling. tfb_id={}", lTfBuilderId);
+          WDDLOG_RL(10000, "Scheduling of Tf failed. to_tfb_id={} reason=grpc_error", lTfBuilderId);
+          WDDLOG("Removing TfBuilder from scheduling. tfb_id={} reason=BuildTfRequest_failed", lTfBuilderId);
 
           lRpcCli.put();
 
-          requestDropAllFromSchedule(lTfId);
+          // NOTE: if tfbuilder was not reached, stfsender will be able to clean the stfs on their own
+          //       if tfbuilder was reached (grpc timeout), it will continue to fetch the TF
+          // requestDropAllFromSchedule(lTfId);
+
           mConnManager.removeTfBuilder(lTfBuilderId);
           mTfBuilderInfo.removeReadyTfBuilder(lTfBuilderId);
         }

--- a/src/TfScheduler/TfSchedulerTfBuilderInfo.h
+++ b/src/TfScheduler/TfSchedulerTfBuilderInfo.h
@@ -38,7 +38,7 @@ namespace o2::DataDistribution
 using namespace std::chrono_literals;
 
 struct TfBuilderInfo {
-  std::chrono::system_clock::time_point mUpdateLocalTime;
+  std::chrono::steady_clock::time_point mUpdateLocalTime;
   TfBuilderUpdateMessage mTfBuilderUpdate;
   std::uint64_t mLastScheduledTf = 0;
   std::uint64_t mEstimatedFreeMemory = 0;
@@ -50,7 +50,7 @@ struct TfBuilderInfo {
 
   TfBuilderInfo() = delete;
 
-  TfBuilderInfo(std::chrono::system_clock::time_point pUpdateLocalTime, const TfBuilderUpdateMessage &pTfBuilderUpdate)
+  TfBuilderInfo(std::chrono::steady_clock::time_point pUpdateLocalTime, const TfBuilderUpdateMessage &pTfBuilderUpdate)
   : mUpdateLocalTime(pUpdateLocalTime),
     mTfBuilderUpdate(pTfBuilderUpdate)
   {

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -59,16 +59,13 @@ class SubTimeFrameReadoutBuilder
 
     std::unique_ptr<SubTimeFrame> lStf = std::move(mStf);
 
-    // mark as NULL if data was rejected
-    if (lStf && !mAcceptStfData) {
-      lStf->setOrigin(SubTimeFrame::Header::Origin::eNull);
-    }
+    auto lRet = (lStf && mAcceptStfData) ? std::optional<std::unique_ptr<SubTimeFrame>>(std::move(lStf)) : std::nullopt;
 
     mStf = nullptr;
     mAcceptStfData = true;
     mFirstFiltered.clear();
 
-    return (lStf) ? std::optional<std::unique_ptr<SubTimeFrame>>(std::move(lStf)) : std::nullopt;
+    return lRet;
   }
 
   // for aggregation of threshold scan data

--- a/src/common/SubTimeFrameDataModel.h
+++ b/src/common/SubTimeFrameDataModel.h
@@ -310,7 +310,7 @@ class SubTimeFrame : public IDataModelObject
       eInvalid = -1,
       eReadout = 1,
       eReadoutTopology, // MFT/ITS topology run
-      eNull
+      eNull     // TODO: remove after DD v1.4
     } mOrigin = eInvalid;
     std::uint64_t mCreationTimeMs = sInvalidTimeMs; // miliseconds since unix epoch
 

--- a/src/common/base/Utilities.h
+++ b/src/common/base/Utilities.h
@@ -73,6 +73,20 @@ double since(std::chrono::time_point<clock_t, duration_t> const& start)
   }
 }
 
+// return duration in desired units, with provided finish
+template <
+    class unit       = std::chrono::seconds,
+    class clock_t    = std::chrono::steady_clock,
+    class duration_t = std::chrono::microseconds >
+double since(std::chrono::time_point<clock_t, duration_t> const& start, std::chrono::time_point<clock_t, duration_t> const& finish)
+{
+  if constexpr (std::is_same_v<unit, std::chrono::seconds>) {
+    return std::chrono::duration<double>(finish - start).count();
+  } else {
+    return std::chrono::duration<double>(finish - start) / unit(1);
+  }
+}
+
 template <
   typename T,
   size_t N = 1024,

--- a/src/common/discovery/ConfigConsul.h
+++ b/src/common/discovery/ConfigConsul.h
@@ -97,7 +97,7 @@ public:
         lNumConsulTries += 1;
         IDDLOG("Connecting to Consul. endpoint={}", mEndpoint);
         mConsul = std::make_unique<ppconsul::Consul>(mEndpoint,
-          ppconsul::kw::connect_timeout = std::chrono::milliseconds{10000},
+          ppconsul::kw::connect_timeout = std::chrono::milliseconds{5000},
           ppconsul::kw::request_timeout = std::chrono::milliseconds{30000});
 
         mConsul->get("/");

--- a/src/common/rpc/TfBuilderRpcClient.h
+++ b/src/common/rpc/TfBuilderRpcClient.h
@@ -95,6 +95,7 @@ public:
     auto lStart = std::chrono::steady_clock::now();
 
     ClientContext lContext;
+    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(5000));
     pResponse.Clear();
 
     auto lStatus = mStub->BuildTfRequest(&lContext, pTfInfo, &pResponse);

--- a/src/common/rpc/TfSchedulerRpcClient.cxx
+++ b/src/common/rpc/TfSchedulerRpcClient.cxx
@@ -266,7 +266,7 @@ bool TfSchedulerRpcClient::TfBuilderUpdate(TfBuilderUpdateMessage &pMsg) {
     return true;
   }
 
-  EDDLOG_GRL(2000, "gRPC: TfBuilderUpdate error. code={} message={}", lStatus.error_code(), lStatus.error_message());
+  DDDLOG_GRL(1000, "gRPC: TfBuilderUpdate error. code={} message={}", lStatus.error_code(), lStatus.error_message());
   return false;
 }
 

--- a/src/common/rpc/TfSchedulerRpcClient.h
+++ b/src/common/rpc/TfSchedulerRpcClient.h
@@ -54,7 +54,7 @@ public:
       // check for terminal states and exit
       if (mTfSchedulerConf.partition_state() == PartitionState::PARTITION_ERROR ||
           mTfSchedulerConf.partition_state() == PartitionState::PARTITION_TERMINATED) {
-        WDDLOG_RL(1000, "Partition State: {}", PartitionState_Name(mTfSchedulerConf.partition_state()));
+        WDDLOG_RL(10000, "Partition State: {}", PartitionState_Name(mTfSchedulerConf.partition_state()));
         mShouldRetryStart = false;
         return false;
       }


### PR DESCRIPTION
tfscheduler: fix under-reporting of incomplete tfs
tfscheduler: report global accept/rejects rates and sizes
tfscheduler: improve scheduling of incomplete tfs on completion and timeout
tfbuilder:  handle the case when all stfs are not available any longer or grpc requests failed
consul: decrease connection timeout for retries to 5 seconds