### PR TITLE
DataDistribution 1.4.1

### DIFF
--- a/src/StfBuilder/StfBuilderDevice.cxx
+++ b/src/StfBuilder/StfBuilderDevice.cxx
@@ -491,9 +491,6 @@ void StfBuilderDevice::PostRun()
     I().mDiscoveryConfig->write();
   }
 
-  // remove run number from monitoring
-  DataDistMonitor::enable_datadist(0, DataDistLogger::sPartitionIdStr);
-
   IDDLOG("Exiting running state. RunNumber: {}", DataDistLogger::sRunNumberStr);
 }
 

--- a/src/StfSender/StfSenderDevice.cxx
+++ b/src/StfSender/StfSenderDevice.cxx
@@ -207,9 +207,6 @@ void StfSenderDevice::PostRun()
   // stop accepting data
   I().mAcceptingData = false;
 
-  // disable run number in monitoring
-  DataDistMonitor::enable_datadist(0, I().mPartitionId);
-
   // update running state
   if (!standalone() && I().mDiscoveryConfig) {
     auto& lStatus = I().mDiscoveryConfig->status();

--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -442,11 +442,6 @@ void StfSenderOutput::sendStfToTfBuilder(const std::uint64_t pStfId, const std::
 void StfSenderOutput::StfDropThread()
 {
   DDDLOG("Starting DataDropThread thread.");
-  // decrease the priority
-#if defined(__linux__)
-  if (nice(5)) {}
-#endif
-
   std::uint64_t lNumDroppedStfs = 0;
 
   while (mRunning) {
@@ -466,8 +461,10 @@ void StfSenderOutput::StfDropThread()
     lNumDroppedStfs += 1;
     {
       std::scoped_lock lLock(mCounters.mCountersLock);
-      mCounters.mValues.mBuffered.mSize -= lStfSize;
-      mCounters.mValues.mBuffered.mCnt -= 1;
+      if (mCounters.mValues.mBuffered.mCnt > 0) {
+        mCounters.mValues.mBuffered.mSize -= lStfSize;
+        mCounters.mValues.mBuffered.mCnt -= 1;
+      }
     }
   }
 

--- a/src/StfSender/StfSenderOutput.h
+++ b/src/StfSender/StfSenderOutput.h
@@ -75,6 +75,9 @@ public:
     return mCounters.mValues;
   }
   StdSenderOutputCounters::Values resetCounters() {
+    // Empty the drop queue
+    mDropQueue.flush();
+
     std::scoped_lock lLock(mCounters.mCountersLock);
     auto lRet = mCounters.mValues;
     mCounters.mValues = StdSenderOutputCounters::Values();

--- a/src/StfSender/StfSenderOutputUCX.h
+++ b/src/StfSender/StfSenderOutputUCX.h
@@ -151,6 +151,7 @@ public:
         }
       }
       if (!lReloadCache) {
+        EDDLOG_RL(1000, "regionLookup: region not found: msg_ptr={} len={}", pPtr, pSize);
         throw std::runtime_error("no region matched");
       }
 

--- a/src/TfBuilder/TfBuilderDevice.cxx
+++ b/src/TfBuilder/TfBuilderDevice.cxx
@@ -354,9 +354,6 @@ void TfBuilderDevice::PostRun()
   // flush the file writter
   mFileSink.flush();
 
-  // reemove run number from monitoring
-  DataDistMonitor::enable_datadist(0, mPartitionId);
-
   IDDLOG("Exiting running state. RunNumber: {}", DataDistLogger::sRunNumberStr);
 }
 

--- a/src/TfBuilder/TfBuilderInputUCX.h
+++ b/src/TfBuilder/TfBuilderInputUCX.h
@@ -59,7 +59,8 @@ struct TfBuilderUCXConnInfo {
   std::mutex mStfSenderIoLock;
 
   /// cache of unpacked remote rma keys
-  std::map<std::string, ucp_rkey_h> mRemoteKeys;
+  std::shared_mutex mRemoteKeysLock;
+    std::map<std::string, ucp_rkey_h> mRemoteKeys;
 
   /// Signal that peer connection has problems
   std::atomic_bool mConnError = false;
@@ -96,6 +97,7 @@ public:
   struct StfMetaRdmaInfo {
     UCXIovStfHeader mStfMeta;
     std::vector<void*> mTxgPtrs;
+    double mRdmaTimeMs;
   };
 
   bool createMetadata(const void *pPtr, const std::size_t pLen, UCXIovStfHeader &lMeta /* out */) {
@@ -196,7 +198,7 @@ private:
   std::thread mListenerThread;
   std::uint32_t mNumStfSenders;
   ConcurrentQueue<std::tuple<std::string, unsigned, ucp_conn_request_h> > mConnRequestQueue;
-  std::mutex mConnectionMapLock;
+  std::shared_mutex mConnectionMapLock;
     std::map<std::string, std::unique_ptr<TfBuilderUCXConnInfo>> mConnMap;
 
 public:

--- a/src/TfScheduler/TfSchedulerConnManager.cxx
+++ b/src/TfScheduler/TfSchedulerConnManager.cxx
@@ -356,7 +356,7 @@ void TfSchedulerConnManager::ConnectTfBuilderUCXThread(const std::string lStfSen
     ConnectTfBuilderUCXResponse lResponse;
     const auto lGrpcStatus = lRpcClient->ConnectTfBuilderUCXRequest(lParam, lResponse);
     if(!lGrpcStatus.ok()) {
-      EDDLOG_RL(1000, "TfBuilder UCX Connection error: gRPC error when connecting StfSender. stfs_id={} tfb_id={} err_code={} err={}",
+      IDDLOG_RL(1000, "TfBuilder UCX Connection error: gRPC error when connecting StfSender. stfs_id={} tfb_id={} err_code={} err={}",
         lStfSenderId, lTfBuilderId, lGrpcStatus.error_code(), lGrpcStatus.error_message());
       lConnectionsOk = false;
       break;
@@ -364,7 +364,7 @@ void TfSchedulerConnManager::ConnectTfBuilderUCXThread(const std::string lStfSen
 
     // check StfSender status
     if (lResponse.status() != OK) {
-      EDDLOG_RL(1000, "TfBuilder UCX Connection error: cannot connect. stfs_id={} tfb_id={}", lStfSenderId, lTfBuilderId);
+    IDDLOG_RL(1000, "TfBuilder UCX Connection error: cannot connect. stfs_id={} tfb_id={}", lStfSenderId, lTfBuilderId);
       lConnectionsOk = false;
       break;
     }
@@ -395,7 +395,7 @@ void TfSchedulerConnManager::disconnectTfBuilderUCX(const TfBuilderConfigStatus 
   for (auto &[lStfSenderId, lRpcClient] : mStfSenderRpcClients) {
     StatusResponse lResponse;
     if(!lRpcClient->DisconnectTfBuilderUCXRequest(lParam, lResponse).ok()) {
-      EDDLOG_RL(1000, "TfBuilder UCX Disconnection error: gRPC error when connecting StfSender. stfs_id={} tfb_id={}",
+      IDDLOG_RL(5000, "TfBuilder UCX Disconnection error: gRPC error when connecting StfSender. stfs_id={} tfb_id={}",
         lStfSenderId, lTfBuilderId);
       pResponse.set_status(ERROR_GRPC_STF_SENDER);
       continue;
@@ -403,7 +403,7 @@ void TfSchedulerConnManager::disconnectTfBuilderUCX(const TfBuilderConfigStatus 
 
     // check StfSender status
     if (lResponse.status() != 0) {
-      IDDLOG_RL(1000, "TfBuilder disconnection error. stfs_id={} tfb_id={} response={}", lStfSenderId, lTfBuilderId, lResponse.status());
+      IDDLOG_RL(5000, "TfBuilder disconnection error. stfs_id={} tfb_id={} response={}", lStfSenderId, lTfBuilderId, lResponse.status());
       pResponse.set_status(ERROR_STF_SENDER_CONNECTING);
       continue;
     }

--- a/src/TfScheduler/TfSchedulerStfInfo.cxx
+++ b/src/TfScheduler/TfSchedulerStfInfo.cxx
@@ -483,6 +483,11 @@ void TfSchedulerStfInfo::addStfInfo(const StfSenderStfInfo &pStfInfo, SchedulerS
         mRunNumber = lRunNumber;
         IDDLOG("NEW RUN NUMBER: {} {}", pStfInfo.partition().partition_id(), lRunNumber);
         DataDistMonitor::enable_datadist(mRunNumber, pStfInfo.partition().partition_id());
+
+        // set log run number
+        DataDistLogger::sRunNumber = mRunNumber;
+        DataDistLogger::sRunNumberStr = std::to_string(mRunNumber);
+        impl::DataDistLoggerCtx::InitInfoLogger();
       } else if (mRunNumber > lRunNumber) {
         EDDLOG_GRL(500, "New RunNumber is smaller than the previous. run_number={} prev_run_number={}", lRunNumber, mRunNumber);
         pResponse.set_status((!mRunning) ? SchedulerStfInfoResponse::DROP_NOT_RUNNING :
@@ -728,6 +733,11 @@ void TfSchedulerStfInfo::TopoSchedulingThread()
       mRunNumber = lRunNum;
       IDDLOG("NEW RUN NUMBER: {} {}", lTopoStfInfo->mStfInfo.partition().partition_id(), mRunNumber);
       DataDistMonitor::enable_datadist(mRunNumber, lTopoStfInfo->mStfInfo.partition().partition_id());
+
+      // set log run number
+      DataDistLogger::sRunNumber = mRunNumber;
+      DataDistLogger::sRunNumberStr = std::to_string(mRunNumber);
+      impl::DataDistLoggerCtx::InitInfoLogger();
     }
 
     TfBuildingInformation lRequest;

--- a/src/common/MemoryUtils.h
+++ b/src/common/MemoryUtils.h
@@ -632,6 +632,9 @@ private:
   // mReclaimLock must be held!
   void reclaimSHMMessage(const void* pData, const std::size_t pSize)
   {
+    assert ((pSize / ALIGN * ALIGN) == pSize);
+    assert (pSize >= ALIGN);
+
     mFreeRanges += std::make_pair(
       icl::discrete_interval<std::size_t>::right_open(
         reinterpret_cast<std::size_t>(pData), reinterpret_cast<std::size_t>(pData) + pSize),

--- a/src/common/SubTimeFrameBuilder.cxx
+++ b/src/common/SubTimeFrameBuilder.cxx
@@ -75,17 +75,9 @@ bool SubTimeFrameReadoutBuilder::addHbFrames(
     mFirstFiltered.clear();
   }
 
-  if (pHdr.mTimeframeOrbitFirst != 0) {
-    mStf->updateFirstOrbit(pHdr.mTimeframeOrbitFirst);
-  } else {
-    WDDLOG_RL(1000, "READOUT INTERFACE: First orbit in TF is not set.");
-    try {
-      const auto R = RDHReader(pHbFramesBegin[0]);
-      mStf->updateFirstOrbit(R.getOrbit());
-    } catch (...) {
-      EDDLOG("Error getting RDHReader instance. Not using {} HBFs", pHBFrameLen);
-      return false;
-    }
+  mStf->updateFirstOrbit(pHdr.mTimeframeOrbitFirst);
+  if (pHdr.mTimeframeOrbitFirst == 0) {
+    WDDLOG_ONCE("READOUT INTERFACE: First orbit in TF is set to 0.");
   }
 
   // filter empty trigger

--- a/src/common/SubTimeFrameDPL.cxx
+++ b/src/common/SubTimeFrameDPL.cxx
@@ -225,6 +225,11 @@ void StfToDplAdapter::inspect() const
       lIdx += 2;
     }
   }
+
+  // DEBUG: TFs with first tf orbit == 0
+  if (lFirstTForbit == 0) {
+    WDDLOG_RL(500, "DPL output: TF with FirstTForbit == 0. run={} dh_tf_counter={} num_messages={}", lRunNumber, lTfCounter, mMessages.size());
+  }
 }
 
 void StfToDplAdapter::sendToDpl(std::unique_ptr<SubTimeFrame>&& pStf)


### PR DESCRIPTION
- [x] tfscheduler: add run nunber to infologger
- [x] monitor: prevent rate logging without run number 
- [x] tfscheduler: log fix TfBuilder UCX Disconnection error: gRPC error when connecting StfSender
- [x] monitoring: prevent numeric max and mins
- [x] tfscheduler: do not count dropped late stfs into the dropped TFs
- [x] tfbuilder: optimize RDMA loop: move key to pre, and monitoring  to post.