### PR TITLE
DataDistribution v1.4.2

### DIFF
--- a/script/start_Discovery-3FLP-3EPN.sh
+++ b/script/start_Discovery-3FLP-3EPN.sh
@@ -160,6 +160,10 @@ STF_SENDER+=" --mq-config $chainConfig"
 STF_SENDER+=" --monitoring-interval=2.0"
 STF_SENDER+=" --monitoring-log"
 STF_SENDER+=" --shm-monitor=false"
+if [[ $EPN_CNT -eq 0 ]]; then
+  STF_SENDER+=" --stand-alone"
+fi
+
 
 TF_BUILDER="TfBuilder"
 TF_BUILDER+=" --discovery-net-if=$EPN_NETIF"

--- a/src/TfBuilder/TfBuilderInputUCX.h
+++ b/src/TfBuilder/TfBuilderInputUCX.h
@@ -21,6 +21,7 @@
 
 #include <SubTimeFrameDataModel.h>
 #include <ConcurrentQueue.h>
+#include <DataDistributionOptions.h>
 
 #include <UCXUtilities.h>
 #include <ucp/api/ucp.h>
@@ -171,6 +172,7 @@ private:
     std::unordered_map<std::string, std::size_t> mStfSenderToWorkerMap;
     std::unordered_map<std::string, std::shared_ptr<ConcurrentQueue<StfMetaRdmaInfo> > >  mStfMetaWorkerQueues;
   std::vector<std::thread> mThreadPool;
+  bool mRdmaPollingWait = UcxPollForRDMACompletionDefault;
 
   // STF postprocess threads
   ConcurrentQueue<StfMetaRdmaInfo> mStfPostprocessQueue;

--- a/src/common/SubTimeFrameDPL.h
+++ b/src/common/SubTimeFrameDPL.h
@@ -42,9 +42,12 @@ class StfToDplAdapter : public ISubTimeFrameVisitor
     }
 
     if (getenv("DATADIST_NEW_DPL_CHAN")) {
-      IDDLOG("StfToDplAdapter: sending reduced-header split-payload messages.");
-      mReducedHdr = true;
+      if ("0" == std::string(getenv("DATADIST_NEW_DPL_CHAN"))) {
+        mReducedHdr = false;
+      }
     }
+
+    IDDLOG("StfToDplAdapter: sending reduced-header split-payload messages={}", mReducedHdr);
   }
 
   virtual ~StfToDplAdapter() = default;
@@ -63,7 +66,7 @@ class StfToDplAdapter : public ISubTimeFrameVisitor
  private:
   std::atomic_bool mRunning = true;
   bool mInspectChannel = false;
-  bool mReducedHdr = false;
+  bool mReducedHdr = true;
 
   std::vector<FairMQMessagePtr> mMessages;
   FairMQChannel& mChan;

--- a/src/common/discovery/DataDistributionOptions.h
+++ b/src/common/discovery/DataDistributionOptions.h
@@ -83,17 +83,21 @@ static constexpr std::uint64_t UcxStfSenderThreadPoolSizeDefault = 8;
 // Define maximum number of concurrent STF transfers
 // The value should not be much grater than UcxTfBuilderThreadPoolSize as the requests will will not be processed immediately.
 static constexpr std::string_view MaxNumStfTransfersKey = "MaxNumStfTransfers";
-static constexpr std::uint64_t MaxNumStfTransferDefault = 8;
+static constexpr std::uint64_t MaxNumStfTransferDefault = 300;
 
 // Stf Request selection method: "random", "linear", "stfsize"
 static constexpr std::string_view StfSenderIdxSelectionMethodKey = "StfSenderIdxSelectionMethod";
 static constexpr std::string_view StfSenderIdxSelectionMethodDefault = "random";
 
+// Stf Request thread pool. Parallelize the grpc calls to all StfSenders,
+static constexpr std::string_view StfSenderGrpcThreadPoolSizeKey = "StfSenderGrpcThreadPoolSize";
+static constexpr std::uint64_t StfSenderGrpcThreadPoolSizeDefault = 8;
+
 
 /// UCX transport
 // Size of receiver treadpool. Default 0 (number of cpu cores)
 static constexpr std::string_view UcxTfBuilderThreadPoolSizeKey = "UcxTfBuilderThreadPoolSize";
-static constexpr std::uint64_t UcxTfBuilderThreadPoolSizeDefault = 2;
+static constexpr std::uint64_t UcxTfBuilderThreadPoolSizeDefault = 1;
 
 // Number of rma_get operation in flight, per ucx thread
 // NOTE: deprecated in DD 1.4

--- a/src/common/discovery/DataDistributionOptions.h
+++ b/src/common/discovery/DataDistributionOptions.h
@@ -81,7 +81,7 @@ static constexpr std::uint64_t UcxStfSenderThreadPoolSizeDefault = 8;
 ////////////////////////////////////////////////////////////////////////////////
 
 // Define maximum number of concurrent STF transfers
-// The value should not be much grater than UcxTfBuilderThreadPoolSize as the requests will will not be processed immediately.
+// The value should be greater than max number of FLPs.
 static constexpr std::string_view MaxNumStfTransfersKey = "MaxNumStfTransfers";
 static constexpr std::uint64_t MaxNumStfTransferDefault = 300;
 
@@ -95,14 +95,13 @@ static constexpr std::uint64_t StfSenderGrpcThreadPoolSizeDefault = 8;
 
 
 /// UCX transport
-// Size of receiver treadpool. Default 0 (number of cpu cores)
+// Size of receiver treadpool. Default 1, works best. Should not be set over 2, to avoid congestion on the receiver.
 static constexpr std::string_view UcxTfBuilderThreadPoolSizeKey = "UcxTfBuilderThreadPoolSize";
 static constexpr std::uint64_t UcxTfBuilderThreadPoolSizeDefault = 1;
 
-// Number of rma_get operation in flight, per ucx thread
-// NOTE: deprecated in DD 1.4
-// static constexpr std::string_view UcxNumConcurrentRmaGetOpsKey = "UcxNumConcurrentRmaGetOps";
-// static constexpr std::uint64_t UcxNumConcurrentRmaGetOpsDefault = 32;
+// Use polling or blocking waiting method for RDMA completion.
+static constexpr std::string_view UcxPollForRDMACompletionKey = "UcxPollForRDMACompletion";
+static constexpr bool UcxPollForRDMACompletionDefault = false;
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/common/rpc/StfSenderRpcClient.h
+++ b/src/common/rpc/StfSenderRpcClient.h
@@ -54,6 +54,7 @@ public:
   // rpc DisconnectTfBuilderRequest(TfBuilderEndpoint) returns (StatusResponse) { }
   grpc::Status DisconnectTfBuilderRequest(const TfBuilderEndpoint &pParam, StatusResponse &pRet /*out*/) {
     ClientContext lContext;
+    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(10000));
     return mStub->DisconnectTfBuilderRequest(&lContext, pParam, &pRet);
   }
 
@@ -67,6 +68,7 @@ public:
   //rpc DisconnectTfBuilderUCXRequest(TfBuilderUCXEndpoint) returns (StatusResponse) { }
   grpc::Status DisconnectTfBuilderUCXRequest(const TfBuilderUCXEndpoint &pParam, StatusResponse &pRet) {
     ClientContext lContext;
+    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::seconds(10000));
     return mStub->DisconnectTfBuilderUCXRequest(&lContext, pParam, &pRet);
   }
 


### PR DESCRIPTION
stfsender: fix deadlock when FLP-standalone memory pressure test is active
tfscheduler: publish TF rates of ITS threshold scans
tfbuilder: parallelize stf request grpc calls
tfbuilder: add blocking mode for rdma (optional, saves 0.5 CPU core)
data-model: make new hdr scheme default (O2-2814)