### PR TITLE
DataDistribution 1.4.3

### DIFF
--- a/src/StfSender/StfSenderDevice.cxx
+++ b/src/StfSender/StfSenderDevice.cxx
@@ -287,6 +287,11 @@ void StfSenderDevice::StfReceiverThread()
 
     DDMON_RATE("stfsender", "stf_input", lStf->getDataSize());
     DDMON("stfsender", "stf_input.id", lStf->id());
+    DDMON("stfsender", "stf_input.delay_ms",
+      std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now()).time_since_epoch().count()/1000.0 -
+      lStf->header().mCreationTimeMs
+    );
+
     I().queue(eReceiverOut, std::move(lStf));
   }
 

--- a/src/StfSender/StfSenderOutputUCX.cxx
+++ b/src/StfSender/StfSenderOutputUCX.cxx
@@ -280,7 +280,10 @@ void StfSenderOutputUCX::visit(const SubTimeFrame &pStf, void *pData)
     for (auto& lSubSpecMapIter : lDataIdentMapIter.second) {
       for (auto& lStfDataIter : lSubSpecMapIter.second) {
         if (lStfDataIter.mHeader) {
-          assert (lStfDataIter.mDataParts.size() > 0);
+          if (lStfDataIter.mDataParts.size() == 0) {
+            EDDLOG_GRL(10000, "StfSenderOutput: Data format error: O2 header without data payload. Check the FLP-workflow");
+            continue;
+          }
           // add the header
           auto lHdrMeta = lStfUCXMeta->mutable_stf_hdr_meta()->add_stf_hdr_iov();
           lHdrMeta->set_hdr_data(lStfDataIter.mHeader->GetData(), lStfDataIter.mHeader->GetSize());

--- a/src/TfBuilder/TfBuilderDevice.cxx
+++ b/src/TfBuilder/TfBuilderDevice.cxx
@@ -421,7 +421,7 @@ void TfBuilderDevice::TfForwardThread()
 
     if (!mStandalone) {
       try {
-        IDDLOG_RL(5000, "Forwarding a new TF to DPL. tf_id={} stf_size={:d} unique_equipments={} total={}",
+        IDDLOG_RL(5000, "Forwarding a new TF to DPL. tf_id={} size={} unique_equipments={} total={}",
           lTfId, lTf->getDataSize(), lTf->getEquipmentIdentifiers().size(), mTfFwdTotalTfCount);
 
         // adapt headers to include DPL processing header on the stack

--- a/src/TfBuilder/TfBuilderInput.cxx
+++ b/src/TfBuilder/TfBuilderInput.cxx
@@ -291,9 +291,6 @@ void TfBuilderInput::StfDeserializingThread()
 void TfBuilderInput::StfMergerThread()
 {
   using namespace std::chrono_literals;
-  using hres_clock = std::chrono::high_resolution_clock;
-
-  auto lRateStartTime = hres_clock::now();
 
   std::uint64_t lNumBuiltTfs = 0;
 
@@ -337,16 +334,7 @@ void TfBuilderInput::StfMergerThread()
     mRpc->recordTfBuilt(*lTf);
 
     DDDLOG_RL(5000, "Building of TF completed. tf_id={} duration_ms={:.4} total_tf={}", lTfId, lBuildDurationMs, lNumBuiltTfs);
-
-    {
-      const auto lNow = hres_clock::now();
-      const auto lTfDur = std::chrono::duration<double>(lNow - lRateStartTime);
-      lRateStartTime = lNow;
-      const auto lRate = (1.0 / lTfDur.count());
-
-      DDMON("tfbuilder", "data_input.rate", (lRate * lTf->getDataSize()));
-      DDMON("tfbuilder", "merge.receive_span_ms", lBuildDurationMs);
-    }
+    DDMON("tfbuilder", "merge.receive_span_ms", lBuildDurationMs);
 
     // Queue out the TF for consumption
     DDMON_RATE("tfbuilder", "tf_input", lTf->getDataSize());

--- a/src/TfBuilder/TfBuilderInputUCX.cxx
+++ b/src/TfBuilder/TfBuilderInputUCX.cxx
@@ -66,13 +66,9 @@ static ucs_status_t ucp_am_data_cb(void *arg, const void *header, size_t header_
       * data transfer.
       */
 
-    EDDLOG_RL(1000, "ucp_am_data_cb RNDV stf_meta_size={}", length);
-
-    lInputUcx->pushRndvMetadata(data, length);
-    return UCS_INPROGRESS;
+    EDDLOG_RL(10000, "UCX: Unexpected ucp_am_data_cb RNDV stf_meta_size={}", length);
+    return UCS_OK;
   }
-
-  assert (param->recv_attr & UCP_AM_RECV_ATTR_FLAG_DATA);
 
   // Translate data to UCX metadata message and queue
   UCXIovStfHeader lMeta;

--- a/src/TfBuilder/TfBuilderInputUCX.h
+++ b/src/TfBuilder/TfBuilderInputUCX.h
@@ -56,9 +56,6 @@ struct TfBuilderUCXConnInfo {
   std::string mStfSenderId;
   std::string mStfSenderIp;
 
-  /// Lock to ensure only one thread is using the endpoint at any time
-  std::mutex mStfSenderIoLock;
-
   /// cache of unpacked remote rma keys
   std::shared_mutex mRemoteKeysLock;
     std::map<std::string, ucp_rkey_h> mRemoteKeys;

--- a/src/TfBuilder/TfBuilderInputUCX.h
+++ b/src/TfBuilder/TfBuilderInputUCX.h
@@ -126,10 +126,6 @@ public:
     mStfPostprocessQueue.push(std::move(pInfo));
   }
 
-  void pushRndvMetadata(void* pUcxDesc, const std::size_t pStfMetaLen) {
-    mStfMetaRndvQueue.push(std::make_tuple(pUcxDesc, pStfMetaLen));
-  }
-
   void handle_client_ep_error(TfBuilderUCXConnInfo *pConn, ucs_status_t pStatus) {
 
     if (pConn) {
@@ -159,9 +155,6 @@ private:
   // STF request queue
   ConcurrentQueue<std::string> &mStfReqQueue;
   std::size_t mThreadPoolSize;
-
-  /// STF UCX metadata queue
-  ConcurrentQueue<std::tuple<void*, std::size_t>> mStfMetaRndvQueue;
 
   // STF preprocess threads
   ConcurrentQueue<UCXIovStfHeader> mStfPreprocessQueue;

--- a/src/TfBuilder/TfBuilderRpc.cxx
+++ b/src/TfBuilder/TfBuilderRpc.cxx
@@ -649,6 +649,7 @@ bool TfBuilderRpcImpl::recordStfReceived(const std::string &pStfSenderId, const 
       mNumReqInFlight -= 1;
     }
     mNumInFlightCond.notify_one();
+    DDMON("tfbuilder", "merge.num_stf_in_flight", mNumReqInFlight);
   }
 
   // record completion time

--- a/src/common/ucxtools/UCXUtilities.h
+++ b/src/common/ucxtools/UCXUtilities.h
@@ -157,12 +157,14 @@ static inline
 bool register_am_callback(dd_ucp_worker &worker, unsigned id, ucp_am_recv_callback_t ucp_am_cb, void *cb_arg)
 {
   ucp_am_handler_param_t am_param;
-  am_param.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID |
-                        UCP_AM_HANDLER_PARAM_FIELD_CB |
-                        UCP_AM_HANDLER_PARAM_FIELD_ARG;
+  am_param.field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID   |
+                        UCP_AM_HANDLER_PARAM_FIELD_CB   |
+                        UCP_AM_HANDLER_PARAM_FIELD_ARG  |
+                        UCP_AM_HANDLER_PARAM_FIELD_FLAGS;
   am_param.id         = id;
   am_param.cb         = ucp_am_cb;
   am_param.arg        = cb_arg;
+  am_param.flags      = UCP_AM_FLAG_WHOLE_MSG;
 
   auto status = ucp_worker_set_am_recv_handler(worker.ucp_worker, &am_param);
   if (status != UCS_OK) {


### PR DESCRIPTION
- stfsender: enforce processing of complete meta messages, and warn on broken data model on flp
- allow transmission of null data payloads (FIT compression workflows)
-  monitoring: publish duration of FLP-workflow-qc processing
- tfbuilder: prevent network congestion with multi-ucx_worker option
