### PR TITLE
DataDistribution v1.4.4

### DIFF
--- a/src/StfSender/StfSenderDevice.cxx
+++ b/src/StfSender/StfSenderDevice.cxx
@@ -214,11 +214,6 @@ void StfSenderDevice::PostRun()
     I().mDiscoveryConfig->write();
   }
 
-  // reset counters
-  if (I().mOutputHandler) {
-    I().mOutputHandler->resetCounters();
-  }
-
   IDDLOG("Exiting running state. RunNumber: {}", DataDistLogger::sRunNumberStr);
 }
 

--- a/src/StfSender/StfSenderDevice.h
+++ b/src/StfSender/StfSenderDevice.h
@@ -110,7 +110,7 @@ class StfSenderDevice : public DataDistDevice
     std::unique_ptr<StfSenderOutput> mOutputHandler;
 
     /// RPC service
-    StfSenderRpcImpl mRpcServer;
+    std::unique_ptr<StfSenderRpcImpl> mRpcServer;
 
     /// Info thread
     std::thread mInfoThread;

--- a/src/StfSender/StfSenderOutput.h
+++ b/src/StfSender/StfSenderOutput.h
@@ -74,20 +74,18 @@ public:
     std::scoped_lock lLock(mCounters.mCountersLock);
     return mCounters.mValues;
   }
-  StdSenderOutputCounters::Values resetCounters() {
-    // Empty the drop queue
-    mDropQueue.flush();
+  void resetCounters() {
 
-    std::scoped_lock lLock(mCounters.mCountersLock);
-    auto lRet = mCounters.mValues;
-    mCounters.mValues = StdSenderOutputCounters::Values();
-    mLastStfId = 0;
-    {
+    { // clear the state
       std::scoped_lock lMapLock(mStfKeepMapLock);
       mStfKeepMap.clear();
     }
 
-    return lRet;
+    { // clear the buffers
+      std::scoped_lock lLock(mCounters.mCountersLock);
+      mCounters.mValues = StdSenderOutputCounters::Values();
+      mLastStfId = 0;
+    }
   }
 
  private:

--- a/src/StfSender/StfSenderOutputDefs.h
+++ b/src/StfSender/StfSenderOutputDefs.h
@@ -30,6 +30,8 @@ struct StdSenderOutputCounters {
   std::mutex mCountersLock;
 
   struct Values {
+    std::uint32_t mSchedulerStfRejectedCnt = 0;
+
     // buffer state
     struct {
       std::uint64_t mSize = 0;

--- a/src/StfSender/StfSenderRpc.cxx
+++ b/src/StfSender/StfSenderRpc.cxx
@@ -159,10 +159,15 @@ void StfSenderRpcImpl::stop()
 
 // rpc TerminatePartition(PartitionInfo) returns (PartitionResponse) { }
 ::grpc::Status StfSenderRpcImpl::TerminatePartition(::grpc::ServerContext* /*context*/,
-  const PartitionInfo* /*request*/, PartitionResponse* response)
+  const PartitionInfo* request, PartitionResponse* response)
 {
-  DDDLOG("TerminatePartition request received.");
-  response->set_partition_state(PartitionState::PARTITION_TERMINATING);
+  if (request->partition_id() != mPartitionId) {
+    response->set_partition_state(PartitionState::PARTITION_UNKNOWN);
+    return Status::CANCELLED;
+  }
+
+  IDDLOG("TerminatePartition request received. partition_id={}", request->partition_id());
+
   mTerminateRequested = true;
   return Status::OK;
 }

--- a/src/StfSender/StfSenderRpc.h
+++ b/src/StfSender/StfSenderRpc.h
@@ -36,8 +36,9 @@ class StfSenderOutput;
 class StfSenderRpcImpl final : public StfSenderRpc::Service
 {
  public:
-  StfSenderRpcImpl()
-  : mServer(nullptr)
+  StfSenderRpcImpl(const std::string &pPartitionId)
+  : mPartitionId(pPartitionId),
+    mServer(nullptr)
   { }
 
   virtual ~StfSenderRpcImpl() { }
@@ -80,6 +81,7 @@ class StfSenderRpcImpl final : public StfSenderRpc::Service
   bool isTerminateRequested() const { return mTerminateRequested; }
 
  private:
+  std::string mPartitionId;
   bool mTerminateRequested = false;
   std::unique_ptr<Server> mServer = nullptr;
   StfSenderOutput *mOutput = nullptr;

--- a/src/TfBuilder/TfBuilderDevice.cxx
+++ b/src/TfBuilder/TfBuilderDevice.cxx
@@ -330,7 +330,6 @@ void TfBuilderDevice::PreRun()
 
   // In Running state
   mInRunningState = true;
-  DDMON("tfbuilder", "running", 1);
 }
 
 // Get here when ConditionalRun returns false
@@ -344,14 +343,13 @@ void TfBuilderDevice::PostRun()
 
   // Not in Running state
   mInRunningState = false;
-  DDMON("tfbuilder", "running", 0);
 
   // update running state
   auto& lStatus = mDiscoveryConfig->status();
   lStatus.mutable_info()->set_process_state(BasicInfo::NOT_RUNNING);
   mDiscoveryConfig->write();
 
-  // flush the file writter
+  // flush the file writer
   mFileSink.flush();
 
   IDDLOG("Exiting running state. RunNumber: {}", DataDistLogger::sRunNumberStr);
@@ -363,14 +361,7 @@ bool TfBuilderDevice::ConditionalRun()
     return false;
   }
   // nothing to do here sleep for awhile
-  std::this_thread::sleep_for(500ms);
-
-  {
-    static unsigned sRateLimit_Monitoring = 0;
-    if ((sRateLimit_Monitoring++ % 32) == 0) {
-      DDMON("tfbuilder", "running", 1);
-    }
-  }
+  std::this_thread::sleep_for(100ms);
   return true;
 }
 

--- a/src/TfBuilder/TfBuilderRpc.cxx
+++ b/src/TfBuilder/TfBuilderRpc.cxx
@@ -666,14 +666,21 @@ bool TfBuilderRpcImpl::recordStfReceived(const std::string &pStfSenderId, const 
 
 
 ::grpc::Status TfBuilderRpcImpl::TerminatePartition(::grpc::ServerContext* /*context*/,
-  const ::o2::DataDistribution::PartitionInfo* /*request*/, ::o2::DataDistribution::PartitionResponse* response)
+  const ::o2::DataDistribution::PartitionInfo* request, ::o2::DataDistribution::PartitionResponse* response)
 {
-  IDDLOG("TerminatePartition request received.");
+  const std::string &lPartitionId = mDiscoveryConfig->status().partition().partition_id();
+
+  if (request->partition_id() != lPartitionId) {
+    response->set_partition_state(PartitionState::PARTITION_UNKNOWN);
+    return Status::CANCELLED;
+  }
+
   mTerminateRequested = true;
 
-  response->set_partition_state(PartitionState::PARTITION_TERMINATING);
+  IDDLOG("TerminatePartition request received. partition_id={}", request->partition_id());
 
-  return ::grpc::Status::OK;
+  response->set_partition_state(PartitionState::PARTITION_TERMINATING);
+  return Status::OK;
 }
 
 

--- a/src/TfScheduler/TfSchedulerConnManager.cxx
+++ b/src/TfScheduler/TfSchedulerConnManager.cxx
@@ -417,8 +417,11 @@ bool TfSchedulerConnManager::requestTfBuildersTerminate() {
 
   std::scoped_lock lLock(mStfSenderClientsLock);
 
+  PartitionInfo lPartInfo;
+  lPartInfo.set_partition_id(mPartitionInfo.mPartitionId);
+
   for (auto &lTfBuilder : mTfBuilderRpcClients) {
-    if (!lTfBuilder.second.mClient->TerminatePartition()) {
+    if (!lTfBuilder.second.mClient->TerminatePartition(lPartInfo)) {
       lFailedRpcsForDeletion.push_back(lTfBuilder.first);
     }
   }
@@ -436,8 +439,11 @@ bool TfSchedulerConnManager::requestStfSendersTerminate() {
 
   std::scoped_lock lLock(mStfSenderClientsLock);
 
+  PartitionInfo lPartInfo;
+  lPartInfo.set_partition_id(mPartitionInfo.mPartitionId);
+
   for (auto &lStfSender : mStfSenderRpcClients) {
-    if (!lStfSender.second->TerminatePartition()) {
+    if (!lStfSender.second->TerminatePartition(lPartInfo)) {
       lFailedRpcsForDeletion.push_back(lStfSender.first);
     }
   }

--- a/src/TfScheduler/TfSchedulerInstanceRpc.cxx
+++ b/src/TfScheduler/TfSchedulerInstanceRpc.cxx
@@ -73,7 +73,6 @@ bool TfSchedulerInstanceRpcImpl::start()
 void TfSchedulerInstanceRpcImpl::stop()
 {
   DDDLOG("TfSchedulerInstanceRpcImpl::stop()");
-  mConnManager.stop();
   mStfInfo.stop();
   mTfBuilderInfo.stop();
 
@@ -81,6 +80,11 @@ void TfSchedulerInstanceRpcImpl::stop()
   if (mMonitorThread.joinable()) {
     mMonitorThread.join();
   }
+
+  // Terminate tasks
+  mConnManager.requestTfBuildersTerminate();
+  mConnManager.requestStfSendersTerminate();
+  mConnManager.stop();
 
   if (mServer) {
     mServer->Shutdown();

--- a/src/common/rpc/StfSenderRpcClient.h
+++ b/src/common/rpc/StfSenderRpcClient.h
@@ -134,15 +134,12 @@ public:
   }
 
   // rpc TerminatePartition(PartitionInfo) returns (PartitionResponse) { }
-  bool TerminatePartition() {
+  bool TerminatePartition(const PartitionInfo &pPartInfo) {
     ClientContext lContext;
-    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(2000));
-    lContext.set_wait_for_ready(true);
+    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(500));
 
-    PartitionInfo lPartInfo;
     PartitionResponse lRet;
-
-    mStub->TerminatePartition(&lContext, lPartInfo, &lRet);
+    mStub->TerminatePartition(&lContext, pPartInfo, &lRet);
     return true; // could have been stopped by the ECS
   }
 

--- a/src/common/rpc/TfBuilderRpcClient.h
+++ b/src/common/rpc/TfBuilderRpcClient.h
@@ -114,15 +114,13 @@ public:
   }
 
   //  rpc TerminatePartition(PartitionInfo) returns (PartitionResponse) { }
-  bool TerminatePartition() {
+  bool TerminatePartition(const PartitionInfo &pPartitionInfo) {
     ClientContext lContext;
     // we don't care about the success. TfBuilder will be terminated by ECS
-    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(100));
+    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(500));
 
-    PartitionInfo lPartitionInfo;
     PartitionResponse lResponse;
-
-    auto lStatus = mStub->TerminatePartition(&lContext, lPartitionInfo, &lResponse);
+    auto lStatus = mStub->TerminatePartition(&lContext, pPartitionInfo, &lResponse);
 
     // this is best effort only. ECS could have already stopped them
     DDDLOG("TerminatePartition: TfBuilder. tfb_id={} state={} message={}",


### PR DESCRIPTION
- tfbuilder: fix broken merge.stf_fetch_ms metric
- grpc: verify partition id on terminate requests (EPN-130)
- stfsender: publish number of rejected (late) stfs
- tfbuilder: fix first orbit and run number in DD-info message when reading raw files
