### PR TITLE
DataDistribution v1.4.5

### DIFF
--- a/src/StfSender/StfSenderOutputUCX.h
+++ b/src/StfSender/StfSenderOutputUCX.h
@@ -87,10 +87,10 @@ public:
   }
 
   void handle_client_ep_error(StfSenderUCXConnInfo *pUCXConnInfo, ucs_status_t status) {
-    // TfBuilder gets disconnected?
+    // TfBuilder disconnected?
     if (pUCXConnInfo) {
       pUCXConnInfo->mConnError = true;
-      EDDLOG_GRL(1000, "UCXConnectionError: tfbuilder_id={} err={}", pUCXConnInfo->mTfBuilderId, ucs_status_string(status));
+      IDDLOG_GRL(5000, "UCXConnection: TfBuilder connection terminated. tfbuilder_id={} err={}", pUCXConnInfo->mTfBuilderId, ucs_status_string(status));
       disconnectTfBuilder(pUCXConnInfo->mTfBuilderId);
     }
   }

--- a/src/TfBuilder/TfBuilderInput.cxx
+++ b/src/TfBuilder/TfBuilderInput.cxx
@@ -146,7 +146,7 @@ void TfBuilderInput::StfPacingThread()
 
   while (mState == RUNNING) {
 
-    auto lData = mReceivedDataQueue->pop();
+    auto lData = mReceivedDataQueue->pop_wait_for(500ms);
     if (lData == std::nullopt) {
       continue;
     }
@@ -298,7 +298,7 @@ void TfBuilderInput::StfMergerThread()
 
   while (mState == RUNNING) {
 
-    auto lStfVectorOpt = mStfsForMerging.pop();
+    auto lStfVectorOpt = mStfsForMerging.pop_wait_for(500ms);
     if (lStfVectorOpt == std::nullopt) {
       continue;
     }

--- a/src/TfBuilder/TfBuilderInputUCX.h
+++ b/src/TfBuilder/TfBuilderInputUCX.h
@@ -128,7 +128,7 @@ public:
     if (pConn) {
       pConn->mConnError = true;
 
-      WDDLOG("TfBuilderInputUCX: peer connection error. stfsender_ip={} stfsender_id={} err={}",
+      IDDLOG_GRL(5000, "TfBuilderInputUCX: peer connection error. stfsender_ip={} stfsender_id={} err={}",
         pConn->mStfSenderIp, pConn->mStfSenderId, ucs_status_string(pStatus));
     }
 

--- a/src/common/SubTimeFrameFile.h
+++ b/src/common/SubTimeFrameFile.h
@@ -178,6 +178,21 @@ struct SubTimeFrameFileDataIndex {
 
 std::ostream& operator<<(std::ostream& pStream, const SubTimeFrameFileDataIndex& pIndex);
 }
+
+////////////////////////////////////////////////////////////////////////////////
+/// EosMetadata
+////////////////////////////////////////////////////////////////////////////////
+struct EosMetadata {
+
+  std::string mEosMetaDir;
+
+  std::string mLhcPeriod;
+  std::string mRunNumber;
+  std::string mFileType;
+  std::string mDetectorList;
+};
+
+
 } /* o2::DataDistribution */
 
 #endif /* ALICEO2_SUBTIMEFRAME_FILE_H_ */

--- a/src/common/SubTimeFrameFileSink.h
+++ b/src/common/SubTimeFrameFileSink.h
@@ -51,6 +51,7 @@ class SubTimeFrameFileSink
   static constexpr const char* OptionKeyStfSinkStfPercent = "data-sink-stf-percentage";
   static constexpr const char* OptionKeyStfSinkFileSize = "data-sink-max-file-size";
   static constexpr const char* OptionKeyStfSinkSidecar = "data-sink-sidecar";
+  static constexpr const char* OptionKeyStfSinkEpn2EosMetaDir = "data-sink-epn2eos-meta-dir";
   static bpo::options_description getProgramOptions();
 
   SubTimeFrameFileSink() = delete;
@@ -103,6 +104,8 @@ class SubTimeFrameFileSink
   unsigned mPercentage = 100;
   std::uint64_t mFileSize;
   bool mSidecar = false;
+  std::string mEosMetaDir;
+  std::optional<EosMetadata> mEosMetadataOpt = std::nullopt;
   std::string mHostname;
 
   /// Thread for file writing

--- a/src/common/SubTimeFrameFileWriter.h
+++ b/src/common/SubTimeFrameFileWriter.h
@@ -22,6 +22,7 @@
 #include <boost/filesystem.hpp>
 #include <fstream>
 #include <vector>
+#include <optional>
 
 namespace o2
 {
@@ -39,7 +40,7 @@ class SubTimeFrameFileWriter : public ISubTimeFrameConstVisitor
 
  public:
   SubTimeFrameFileWriter() = delete;
-  SubTimeFrameFileWriter(const boost::filesystem::path& pFileName, bool pWriteInfo = false);
+  SubTimeFrameFileWriter(const boost::filesystem::path& pFileName, bool pWriteInfo, std::optional<EosMetadata> pEosMetadata);
   virtual ~SubTimeFrameFileWriter();
 
   ///
@@ -83,6 +84,9 @@ class SubTimeFrameFileWriter : public ISubTimeFrameConstVisitor
 
   bool mWriteInfo;
   std::ofstream mInfoFile;
+
+  std::optional<EosMetadata> mEosMetadata;
+  boost::filesystem::path mMetaFileName;
 
   std::unique_ptr<char[]> mFileBuf;
   std::unique_ptr<char[]> mInfoFileBuf;

--- a/src/common/base/Utilities.h
+++ b/src/common/base/Utilities.h
@@ -36,12 +36,24 @@ void assume(const bool pPred) {
   }
 }
 
+// helper function to get default LHC period
+static inline
+std::string getDefaultLhcPeriod() {
+  // From O2 CommonServices::datatakingContextSpec()
+  static const char* months[12] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+  time_t now = time(nullptr);
+  auto ltm = gmtime(&now);
+  return std::string(months[ltm->tm_mon]);
+}
+
+// convert enum to numeric value
 template <typename T>
 constexpr auto operator+(const T p) noexcept -> std::enable_if_t<std::is_enum<T>::value, std::underlying_type_t<T>>
 {
   return static_cast<std::underlying_type_t<T>>(p);
 }
 
+// create threads using a object method
 template <class F, class ... Args>
 std::thread create_thread_member(const char* name, F&& f, Args&&... args) {
   char *lName = strdup(name);

--- a/src/common/monitoring/DataDistMonitoring.cxx
+++ b/src/common/monitoring/DataDistMonitoring.cxx
@@ -188,9 +188,7 @@ void DataDistMonitoring::MonitorThread()
         const auto &lAccValues = lKeyRateAccIter.second;
 
         if (lAccValues.mCount < std::numeric_limits<double>::epsilon()) {
-          lMetric.addValue(0.0, lKey + ".size");        // mean
-          lMetric.addValue(0.0, lKey + ".size.min");    // min
-          lMetric.addValue(0.0, lKey + ".size.max");    // max
+          // don't publish size if there were no samples during the monitoring window
           lMetric.addValue(0.0, lKey + ".rate");        // rate
           lMetric.addValue(0.0, lKey + ".throughput");  // thr
         } else {

--- a/src/common/ucxtools/UCXUtilities.h
+++ b/src/common/ucxtools/UCXUtilities.h
@@ -255,7 +255,7 @@ void close_ep_connection(dd_ucp_worker &worker, ucp_ep_h ep)
 {
   ucp_request_param_t param;
   param.op_attr_mask = UCP_OP_ATTR_FIELD_FLAGS;
-  param.flags        = UCP_EP_CLOSE_MODE_FORCE;
+  param.flags        = UCP_EP_CLOSE_FLAG_FORCE;
 
   auto close_req = ucp_ep_close_nbx(ep, &param);
   if (UCS_PTR_IS_PTR(close_req)) {


### PR DESCRIPTION
- file sink: adopt lhc period from AliECS for EOS metadata
- tfbuilder: fix delay during terminating
- monitoring: don’t publish size in rate metric if no datapoints in interval