### PR TITLE
DataDistribution v1.4.5

### DIFF
--- a/src/TfBuilder/TfBuilderDevice.cxx
+++ b/src/TfBuilder/TfBuilderDevice.cxx
@@ -391,7 +391,6 @@ void TfBuilderDevice::TfForwardThread()
     }
 
     if (lTfOpt == std::nullopt) {
-      DDMON("tfbuilder", "data_output.rate", 0);
       DDMON("tfbuilder", "tf_output.sent_size", mTfFwdTotalDataSize);
       DDMON("tfbuilder", "tf_output.sent_count", mTfFwdTotalTfCount);
       continue;

--- a/src/TfBuilder/TfBuilderInputUCX.h
+++ b/src/TfBuilder/TfBuilderInputUCX.h
@@ -163,8 +163,9 @@ private:
     std::unordered_map<std::string, std::shared_ptr<ConcurrentQueue<StfMetaRdmaInfo> > >  mStfMetaWorkerQueues;
   std::vector<std::thread> mThreadPool;
   bool mRdmaPollingWait = UcxPollForRDMACompletionDefault;
+  std::uint64_t mRdmaConcurrentStfSizeMax  = UcxMaxStfSizeForConcurrentFetchBDefault;
 
-  // STF postprocess threads
+  // STF postprocessing threads
   ConcurrentQueue<StfMetaRdmaInfo> mStfPostprocessQueue;
   std::vector<std::thread> mPostThreadPool;
 

--- a/src/TfBuilder/TfBuilderRpc.cxx
+++ b/src/TfBuilder/TfBuilderRpc.cxx
@@ -536,14 +536,13 @@ void TfBuilderRpcImpl::StfRequestThread()
 
         // select the order in which StfSenders are contacted (consul option)
         std::size_t lIdx = getFetchIdx(lReqVector);
-        DDMON("tfbuilder", "merge.request_idx", double(lReqVector.size()) / double(lIdx + 1));
 
         lStfRequest = std::move(lReqVector[lIdx]);
         lReqVector.erase(lReqVector.cbegin() + lIdx);
 
         // Fan out STF grpc requests because it's limitting on how fast one EPN can receive data from many FLPs
         // A single StfDataRequest request takes about 330 us, i.e. fetching 200 STFs -> 70 ms.
-        // This is OK wih runs with many EPNs, but a single EPN should be able to requst all STFs under 10 ms
+        // This is OK wih runs with many EPNs, but a single EPN should be able to request all STFs under 10 ms
         mGrpcStfRequestQueue.push(GrpcStfReqInfo {std::move(lStfRequest), lNumStfs, lNumRequested /*ref*/, lNumExpectedStfs });
       }
 

--- a/src/common/SubTimeFrameDPL.cxx
+++ b/src/common/SubTimeFrameDPL.cxx
@@ -272,9 +272,13 @@ void StfToDplAdapter::sendEosToDpl()
 {
   o2::framework::SourceInfoHeader lDplExitHdr;
   lDplExitHdr.state = o2::framework::InputChannelState::Completed;
+
+  o2::framework::DataProcessingHeader lDplHdr;
+  lDplHdr.creation = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now()).time_since_epoch().count();
+
   const auto lDoneStack = o2::header::Stack(
     o2::header::DataHeader(o2::header::gDataDescriptionInfo, o2::header::gDataOriginAny, 0, 0),
-    o2::framework::DataProcessingHeader(),
+    lDplHdr,
     lDplExitHdr
   );
 

--- a/src/common/discovery/DataDistributionOptions.h
+++ b/src/common/discovery/DataDistributionOptions.h
@@ -97,11 +97,15 @@ static constexpr std::uint64_t StfSenderGrpcThreadPoolSizeDefault = 8;
 /// UCX transport
 // Size of receiver treadpool. Default 1, works best. Should not be set over 2, to avoid congestion on the receiver.
 static constexpr std::string_view UcxTfBuilderThreadPoolSizeKey = "UcxTfBuilderThreadPoolSize";
-static constexpr std::uint64_t UcxTfBuilderThreadPoolSizeDefault = 1;
+static constexpr std::uint64_t UcxTfBuilderThreadPoolSizeDefault = 2;
 
 // Use polling or blocking waiting method for RDMA completion.
 static constexpr std::string_view UcxPollForRDMACompletionKey = "UcxPollForRDMACompletion";
 static constexpr bool UcxPollForRDMACompletionDefault = false;
+
+// Allow smaller STFs to be fetched concurrently to improve TF building time
+static constexpr std::string_view UcxMaxStfSizeForConcurrentFetchBKey = "UcxMaxStfSizeForConcurrentFetchB";
+static constexpr std::uint64_t UcxMaxStfSizeForConcurrentFetchBDefault = std::uint64_t(4) << 20;
 
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- [x] monitoring: consolidate and remove unused metrics
- [x] end of stream: add current time in DataProcessingHeader
- [x] tfbuilder: on stop, push all TFs, then End-of-Stream
- [x] tfbuilder: fix delay during terminating
- [x] file sink: adopt lhc period from AliECS for EOS metadata
- [x] monitoring: don’t publish size in rate metric if no datapoints in interval
- [x] tfbuilder: improve ucx throughput for small stfs (optional)