### PR TITLE
tfscheduler: hand out tokens for stf transfers

### DIFF
--- a/src/StfSender/StfSenderOutputUCX.h
+++ b/src/StfSender/StfSenderOutputUCX.h
@@ -191,7 +191,7 @@ private:
 
   /// UCX objects
 
-  /// context and listener
+  /// context
   ucp_context_h ucp_context;
   boost::container::small_vector<ucx::dd_ucp_worker, 512> mDataWorkers;
 

--- a/src/TfScheduler/CMakeLists.txt
+++ b/src/TfScheduler/CMakeLists.txt
@@ -8,11 +8,12 @@ set(EXE_TFS_SOURCES
   TfSchedulerConnManager
   TfSchedulerTfBuilderInfo
   TfSchedulerStfInfo
+  TfSchedulerTokenManager
   runTfScheduler
 )
 
 add_library(TfScheduler_lib OBJECT ${EXE_TFS_SOURCES})
-target_link_libraries(TfScheduler_lib  base fmqtools discovery rpc monitoring)
+target_link_libraries(TfScheduler_lib  base fmqtools ucxtools discovery rpc monitoring)
 
 add_executable(TfScheduler)
 
@@ -25,7 +26,7 @@ endif()
 target_link_libraries(TfScheduler
   PRIVATE
     TfScheduler_lib
-    base fmqtools discovery rpc monitoring
+    base fmqtools ucxtools discovery rpc monitoring
 )
 
 install(TARGETS TfScheduler RUNTIME DESTINATION bin)

--- a/src/TfScheduler/TfSchedulerInstanceRpc.h
+++ b/src/TfScheduler/TfSchedulerInstanceRpc.h
@@ -17,6 +17,7 @@
 #include "TfSchedulerConnManager.h"
 #include "TfSchedulerTfBuilderInfo.h"
 #include "TfSchedulerStfInfo.h"
+#include "TfSchedulerTokenManager.h"
 
 #include <ConfigConsul.h>
 #include <discovery.grpc.pb.h>
@@ -26,9 +27,7 @@
 #include <map>
 #include <thread>
 
-namespace o2
-{
-namespace DataDistribution
+namespace o2::DataDistribution
 {
 
 using grpc::Server;
@@ -47,7 +46,8 @@ class TfSchedulerInstanceRpcImpl final : public TfSchedulerInstanceRpc::Service
   mPartitionInfo(pPartitionRequest),
   mConnManager(pDiscoveryConfig, pPartitionRequest),
   mTfBuilderInfo(pDiscoveryConfig),
-  mStfInfo(pDiscoveryConfig, mConnManager, mTfBuilderInfo)
+  mStfInfo(pDiscoveryConfig, mConnManager, mTfBuilderInfo),
+  mTokenManager(pDiscoveryConfig)
   { }
 
   virtual ~TfSchedulerInstanceRpcImpl() { }
@@ -109,13 +109,15 @@ class TfSchedulerInstanceRpcImpl final : public TfSchedulerInstanceRpc::Service
   /// Stfs for scheduling
   TfSchedulerStfInfo mStfInfo;
 
+  /// Stf schedule token maker
+  TfSchedulerTokenManager mTokenManager;
+  bool mTokenManagerEnabled = DataDistEnableStfTransferTokensDefault;
+
   /// Partition State. Always update via the method.
   void updatePartitionState(const PartitionState pNewState);
   PartitionState mPartitionState = PartitionState::PARTITION_CONFIGURING;
 };
-}
+
 } /* namespace o2::DataDistribution */
-
-
 
 #endif /* ALICEO2_TF_SCHEDULER_INSTANCE_RPC_H_ */

--- a/src/TfScheduler/TfSchedulerTokenManager.cxx
+++ b/src/TfScheduler/TfSchedulerTokenManager.cxx
@@ -1,0 +1,257 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "TfSchedulerTokenManager.h"
+#include "DataDistMonitoring.h"
+
+
+namespace o2::DataDistribution
+{
+
+using namespace std::chrono_literals;
+
+
+static ucs_status_t ucp_am_token_req_data_cb(void *arg, const void *header, size_t header_length,
+                                  void *data, size_t length, const ucp_am_recv_param_t *param)
+{
+  TfSchedulerTokenManager *lTokenManager = reinterpret_cast<TfSchedulerTokenManager*>(arg);
+  (void) data;
+  (void) length;
+  (void) param;
+  (void) header_length;
+  assert (header_length == sizeof (ucx::io::TokenRequest));
+  assert (param->recv_attr & UCP_AM_RECV_ATTR_FIELD_REPLY_EP);
+
+  TokenRequestInfo lReqInfo;
+  // save the reply endpoint
+  lReqInfo.mReplyEp = param->reply_ep;
+  std::memcpy(&lReqInfo.mRequest, header, sizeof (ucx::io::TokenRequest));
+
+  if (lReqInfo.mRequest.mTokensRequested) {
+    lTokenManager->mTokenRequestQueue.push(lReqInfo);
+  }
+
+#ifndef NDEBUG
+  DDDLOG_RL(1000, "ucp_am_token_req_data_cb: req_popcnt={}", lReqInfo.mRequest.mTokensRequested.popcnt());
+#endif
+
+  return UCS_OK;
+}
+
+static ucs_status_t ucp_am_token_rel_data_cb(void *arg, const void *header, size_t header_length,
+                                  void *data, size_t length, const ucp_am_recv_param_t *param)
+{
+  TfSchedulerTokenManager *lTokenManager = reinterpret_cast<TfSchedulerTokenManager*>(arg);
+  (void) data;
+  (void) length;
+  (void) param;
+  (void) header_length;
+  assert (header_length == sizeof (ucx::io::TokenRequest::BitFieldIdxType));
+
+  ucx::io::TokenRequest::BitFieldIdxType lRelToken;
+  std::memcpy(&lRelToken, header, sizeof(ucx::io::TokenRequest::BitFieldIdxType));
+
+  assert (lRelToken != ucx::io::TokenRequest::BitfieldInvalidIdx);
+
+#ifndef NDEBUG
+  DDDLOG_RL(1000, "ucp_am_token_rel_data_cb: rel_token={}", (lRelToken - 1));
+#endif
+
+  lTokenManager->mReleasedTokens.push(lRelToken);
+
+  return UCS_OK;
+}
+
+static void client_ep_err_cb(void *arg, ucp_ep_h, ucs_status_t status)
+{
+  (void) status;
+  TfBuilderUCXConnInfo *lConnInfo = reinterpret_cast<TfBuilderUCXConnInfo*>(arg);
+  if (lConnInfo) {
+    lConnInfo->mConnError = true;
+  }
+}
+
+TfSchedulerTokenManager::TfSchedulerTokenManager(std::shared_ptr<ConsulTfScheduler> pConfig)
+{
+  mDiscoveryConfig = pConfig;
+  mOutputMap.reserve(300);
+}
+
+bool TfSchedulerTokenManager::start()
+{
+  mTokenResetTimeoutMs = std::chrono::milliseconds(mDiscoveryConfig->getUInt64Param(TokenResetTimeoutMsKey,
+    TokenResetTimeoutMsDefault));
+
+  // Create the UCX context
+  if (!ucx::util::create_ucp_context(&ucp_context)) {
+    EDDLOG("TfSchedulerTokenManager: failed to create UCX context");
+    return false;
+  }
+
+  // create one worker
+  if (!ucx::util::create_ucp_worker(ucp_context, &ucp_worker, "token manager worker")) {
+    return false;
+  }
+
+  // register the am handler for token requests
+  if (!ucx::util::register_am_callback(ucp_worker, ucx::io::AM_TOKEN_REQ, ucp_am_token_req_data_cb, this)) {
+    return false;
+  }
+  // register the am handler for token releases
+  if (!ucx::util::register_am_callback(ucp_worker, ucx::io::AM_TOKEN_REL, ucp_am_token_rel_data_cb, this)) {
+    return false;
+  }
+
+  mRunning = true;
+  mTokenThread = create_thread_member("nft_maker", &TfSchedulerTokenManager::TokenManagerThread, this);
+
+  // add all tokens
+  mTokens.set_all();
+
+  DDDLOG("Started: TfSchedulerTokenManager");
+  return true;
+}
+
+void TfSchedulerTokenManager::stop()
+{
+  mRunning = false;
+
+  if (mTokenThread.joinable()) {
+    mTokenThread.join();
+  }
+
+  DDDLOG("Stopped: TfSchedulerTokenManager");
+}
+
+bool TfSchedulerTokenManager::connectTfBuilder(const std::string &pTfBuilderId, const std::string &lTfBuilderIp, const unsigned lTfBuilderPort)
+{
+  if (!mRunning) {
+    EDDLOG_ONCE("TfSchedulerTokenManager::connectTfBuilder: backend is not started.");
+    return false;
+  }
+  // Check if connection already exists
+  {
+    std::shared_lock lLock(mOutputMapLock);
+
+    if (mOutputMap.count(pTfBuilderId) > 0) {
+      EDDLOG("TfSchedulerTokenManager::connectTfBuilder: TfBuilder is already connected. tfb_id={}", pTfBuilderId);
+      return true;
+    }
+  }
+
+  DDDLOG("TfSchedulerTokenManager::connectTfBuilder: transport starting for tfbuilder_id={}", pTfBuilderId);
+
+  auto lConnInfo = std::make_unique<TfBuilderUCXConnInfo>(*this, ucp_worker, pTfBuilderId);
+
+  // create endpoint for TfBuilder connection
+  DDDLOG("Connect to TfBuilder ip={} port={}", lTfBuilderIp, lTfBuilderPort);
+  if (!ucx::util::create_ucp_client_ep(lConnInfo->mWorker, lTfBuilderIp, lTfBuilderPort,
+    &lConnInfo->ucp_ep, client_ep_err_cb, lConnInfo.get(), pTfBuilderId)) {
+    return false;
+  }
+
+  DDDLOG("TfSchedulerTokenManager::connectTfBuilder: ucx::io::ucx_send_string ip={} port={}", lTfBuilderIp, lTfBuilderPort);
+  const std::string lTfSchedStr = "tfscheduler";
+  if (!ucx::io::ucx_send_string(lConnInfo->mWorker, lConnInfo->ucp_ep, lTfSchedStr)) {
+    EDDLOG("TfSchedulerTokenManager::connectTfBuilder: Sending of local id failed. ip={} port={}", lTfBuilderIp, lTfBuilderPort);
+    return false;
+  }
+
+  // Add the connection to connection map
+  {
+    std::unique_lock lLock(mOutputMapLock);
+    const auto lItOk = mOutputMap.try_emplace(pTfBuilderId, std::move(lConnInfo));
+    if (!lItOk.second) {
+      EDDLOG("connectTfBuilder: TfBuilder connection already exists tfbuilder_id={}", pTfBuilderId);
+      return false;
+    }
+  }
+  DDDLOG("TfSchedulerTokenManager::connectTfBuilder: transport started for tfbuilder_id={}", pTfBuilderId);
+  return true;
+}
+
+void TfSchedulerTokenManager::TokenManagerThread()
+{
+  static unsigned sRandomSeed = 0;
+  std::uint64_t lSpinCounter = 0;
+  std::uint64_t lNumReqSinceReset = 1000; // prevent throttling on init
+
+  std::uint64_t lReqSuccess = 0;
+  std::uint64_t lReqFailed = 0;
+
+  using clock = std::chrono::high_resolution_clock;
+  clock::time_point lRefillTime = clock::now();
+
+  while (mRunning) {
+    lSpinCounter += 1;
+
+    // free all released locks
+    mReleasedTokens.consume_all_atomic([&](const std::uint16_t idx) {
+      mTokens.set(idx);
+      assert (mTokens.get(idx) == true);
+    });
+
+    // prevent burning CPU time when not active
+    if (lNumReqSinceReset == 0) {
+      std::this_thread::sleep_for(5ms);
+    }
+
+    // Refill all locks on a timer to prevent missing locks from failed TfBuilders
+    if ((clock::now() - lRefillTime) >= mTokenResetTimeoutMs) {
+      DDMON("tfscheduler", "tokens.used", (mTokens.max_cnt() - mTokens.popcnt()));
+      DDMON("tfscheduler", "tokens.loops_ps", (lSpinCounter / (1000.0 / mTokenResetTimeoutMs.count())));
+
+      DDMON("tfscheduler", "tokens.req_success", lReqSuccess / (1000.0 / mTokenResetTimeoutMs.count()));
+      DDMON("tfscheduler", "tokens.req_failed", lReqFailed / (1000.0 / mTokenResetTimeoutMs.count()));
+
+      mTokens.set_all();
+      lRefillTime = clock::now();
+      lSpinCounter = 0;
+      lNumReqSinceReset /= 2; // throttle down the CPU usage when there is no requests
+
+      lReqSuccess = 0;
+      lReqFailed = 0;
+    }
+
+    // see if there are any requests
+    ucx::io::TokenRequest::BitFieldIdxType lReplyTokenIdx = ucx::io::TokenRequest::BitfieldInvalidIdx;
+    ucp_ep_h lReplyEp;
+
+    const bool lHaveReq = mTokenRequestQueue.consume_one([&](TokenRequestInfo &lReqInfo) {
+        lReqInfo.mRequest.mTokensRequested &= mTokens;
+        lReplyTokenIdx = lReqInfo.mRequest.mTokensRequested.random_idx(sRandomSeed++);
+        assert ((lReplyTokenIdx == 0) || (lReplyTokenIdx && (lReqInfo.mRequest.mTokensRequested.get(lReplyTokenIdx) == true)));
+        lReplyEp = lReqInfo.mReplyEp;
+    });
+
+    if (lHaveReq) {
+      if (lReplyTokenIdx != ucx::io::TokenRequest::BitfieldInvalidIdx) {
+        assert (mTokens.get(lReplyTokenIdx) == true);
+        mTokens.clr(lReplyTokenIdx);
+        assert (mTokens.get(lReplyTokenIdx) == false);
+        lReqSuccess += 1;
+      } else {
+        lReqFailed += 1;
+      }
+
+      ucx::io::ucx_send_am_hdr(ucp_worker, lReplyEp, ucx::io::AM_TOKEN_REP, &lReplyTokenIdx, sizeof(lReplyTokenIdx));
+
+      lNumReqSinceReset += 1;
+    }
+
+    // prevents burning the cpu core in this thread
+    while (ucp_worker_progress(ucp_worker.ucp_worker) > 0) { }
+  }
+}
+
+} /* o2::DataDistribution */

--- a/src/TfScheduler/TfSchedulerTokenManager.h
+++ b/src/TfScheduler/TfSchedulerTokenManager.h
@@ -1,0 +1,111 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef TF_SCHEDULER_TOKEN_MANAGER_H_
+#define TF_SCHEDULER_TOKEN_MANAGER_H_
+
+#include <ConfigParameters.h>
+#include <ConfigConsul.h>
+#include <DataDistributionOptions.h>
+
+#include <Utilities.h>
+
+#include <UCXUtilities.h>
+#include <UCXSendRecv.h>
+#include <ucp/api/ucp.h>
+
+#include <vector>
+#include <map>
+#include <thread>
+#include <shared_mutex>
+
+#include <boost/lockfree/stack.hpp>
+#include <boost/lockfree/queue.hpp>
+
+namespace o2::DataDistribution
+{
+
+class ConsulConfig;
+class TfSchedulerTokenManager;
+
+struct TokenRequestInfo {
+  ucx::io::TokenRequest mRequest;
+  ucp_ep_h              mReplyEp;
+};
+
+struct TfBuilderUCXConnInfo {
+  TfSchedulerTokenManager &mTokenManager;
+  ucx::dd_ucp_worker &mWorker;
+
+  // peer name
+  std::string mTfBuilderId;
+  // peer lock (thread pool)
+  std::mutex mTfBuilderLock;
+
+  ucp_ep_h ucp_ep;
+
+  std::atomic_bool mConnError = false;
+
+  TfBuilderUCXConnInfo() = delete;
+  TfBuilderUCXConnInfo(TfSchedulerTokenManager &pOutputUCX, ucx::dd_ucp_worker &pWorker, const std::string &pTfBuilderId)
+  : mTokenManager(pOutputUCX),
+    mWorker(pWorker),
+    mTfBuilderId(pTfBuilderId)
+  { }
+};
+
+class TfSchedulerTokenManager
+{
+ public:
+  TfSchedulerTokenManager() = delete;
+  TfSchedulerTokenManager(std::shared_ptr<ConsulTfScheduler> pConfig);
+
+  ~TfSchedulerTokenManager() { }
+
+  bool start();
+  void stop();
+
+
+  bool connectTfBuilder(const std::string &pTfBuilderId, const std::string &lTfBuilderIp, const unsigned lTfBuilderPort);
+
+  void TokenManagerThread();
+
+ private:
+  /// Discovery configuration
+  std::shared_ptr<ConsulTfScheduler> mDiscoveryConfig;
+
+  /// Scheduler threads
+  std::atomic_bool mRunning = false;
+  std::chrono::milliseconds mTokenResetTimeoutMs = std::chrono::milliseconds(TokenResetTimeoutMsDefault);
+  std::thread mTokenThread;
+
+  /// UCX connection
+  ucp_context_h ucp_context;
+  ucx::dd_ucp_worker ucp_worker;
+
+  std::shared_mutex mOutputMapLock;
+    std::unordered_map<std::string, std::unique_ptr<TfBuilderUCXConnInfo>> mOutputMap;
+
+
+public:
+  // token management
+  alignas(256)
+  boost::lockfree::stack<ucx::io::TokenRequest::BitFieldIdxType, boost::lockfree::capacity<512> > mReleasedTokens;
+  boost::lockfree::queue<TokenRequestInfo, boost::lockfree::capacity<512> > mTokenRequestQueue;
+  alignas(256)
+  ucx::io::TokenRequest::Bitfield mTokens;
+};
+
+} /* namespace o2::DataDistribution */
+
+#endif /* TF_SCHEDULER_TOKEN_MANAGER_H_ */

--- a/src/common/discovery/DataDistributionOptions.h
+++ b/src/common/discovery/DataDistributionOptions.h
@@ -32,6 +32,10 @@ static constexpr std::string_view DataDistNetworkTransportDefault = "ucx";
 static constexpr std::string_view DataDistMonitorRpcDurationKey = "DataDistMonitorRpcDuration";
 static constexpr bool DataDistMonitorRpcDurationDefault = false;
 
+// Enable the token manager for stf transfers
+static constexpr std::string_view DataDistEnableStfTransferTokensKey = "DataDistEnableStfTransferTokens";
+static constexpr bool DataDistEnableStfTransferTokensDefault = false;
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /// StfBuilder
@@ -131,6 +135,10 @@ static constexpr std::uint64_t StaleTfTimeoutMsDefault = 1000;
 // Max number of incomplete TFs to keep before considering them stale
 static constexpr std::string_view IncompleteTfsMaxCntKey = "IncompleteTfsMaxCnt";
 static constexpr std::uint64_t IncompleteTfsMaxCntValue = 100;
+
+// Token reset timeout. All tokens are returned to the scheduler, as a protection from failed EPNs.
+static constexpr std::string_view TokenResetTimeoutMsKey = "TokenResetTimeoutMs";
+static constexpr std::uint64_t TokenResetTimeoutMsDefault = 1000;
 
 
 } /* o2::DataDistribution */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,3 +39,18 @@ target_link_libraries(test_FmtPatterns
     Boost::filesystem
 )
 add_test(NAME FmtPatterns_test COMMAND test_FmtPatterns)
+
+
+set(TEST_BITMAP_SOURCES
+  test_Bitmap
+)
+add_executable(test_Bitmap ${TEST_BITMAP_SOURCES})
+target_compile_definitions(test_Bitmap PRIVATE "BOOST_TEST_DYN_LINK=1")
+target_link_libraries(test_Bitmap
+  PUBLIC
+  PRIVATE
+    base
+    Boost::unit_test_framework
+    Boost::filesystem
+)
+add_test(NAME Bitmap_test COMMAND test_Bitmap)

--- a/src/tests/test_Bitmap.cxx
+++ b/src/tests/test_Bitmap.cxx
@@ -1,0 +1,68 @@
+// Copyright CERN and copyright holders of ALICE O2. This software is
+// distributed under the terms of the GNU General Public License v3 (GPL
+// Version 3), copied verbatim in the file "COPYING".
+//
+// See http://alice-o2.web.cern.ch/license for full licensing information.
+//
+// In applying this license CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_MODULE "Bitmap"
+
+#include <boost/test/unit_test.hpp>
+#include <DataDistLogger.h>
+
+#include <iostream>
+
+using namespace o2::DataDistribution;
+
+
+
+BOOST_AUTO_TEST_CASE(GetNextSeqNameTest)
+{
+  {
+    TokenBitfield<220> lField1;
+    TokenBitfield<220> lField2;
+
+    BOOST_CHECK(lField1.empty());
+    BOOST_CHECK(lField2.empty());
+
+    lField1.set_all();
+    BOOST_CHECK(!lField1.empty());
+
+    BOOST_CHECK(lField1.first() == 1);
+    BOOST_CHECK(lField2.first() == TokenBitfield<220>::sInvalidIdx);
+
+
+    lField2.set(23);
+    lField1 &= lField2;
+    BOOST_CHECK(lField1.first() == 23);
+  }
+
+  {
+    TokenBitfield<56> lField1;
+    TokenBitfield<56> lField2;
+
+    lField1.set(53);
+
+    lField2.set(23);
+    lField2.set(53);
+    lField2 &= lField1;
+    BOOST_CHECK(lField2.first() == 53);
+    BOOST_CHECK(lField2.random_idx(0) == 53);
+    BOOST_CHECK(lField2.random_idx(1) == 53);
+    BOOST_CHECK(lField2.random_idx(2) == 53);
+    BOOST_CHECK(lField2.random_idx(3) == 53);
+    BOOST_CHECK(lField2.random_idx(4) == 53);
+    BOOST_CHECK(lField2.random_idx(5) == 53);
+
+    lField2.clr(53);
+    BOOST_CHECK(lField2.empty());
+  }
+
+
+  // std::cerr << format(FmtSubSpec, 0) << std::endl;
+  // DataDistLogger(DataDistSeverity::info, DataDistLogger::log_fmq{}, std::string("{}"));
+}


### PR DESCRIPTION
The aim of this is to improve performance when the data rates approaches installed network capacity. TfBuilders will request exclusive access to StfSenders (FLPs) for RDMA transfers.
This operation is optional, switch is in the consul options.
