### PR TITLE
DataDistribution v1.4.7

### DIFF
--- a/src/StfSender/StfSenderDevice.cxx
+++ b/src/StfSender/StfSenderDevice.cxx
@@ -35,25 +35,7 @@ StfSenderDevice::StfSenderDevice()
 }
 
 StfSenderDevice::~StfSenderDevice()
-{
-  DDDLOG("StfBuilderDevice::Reset()");
-
-  I().mDeviceRunning = false;
-  // wait the Info thread, before closing mTfSchedulerRpcClient
-  if (I().mInfoThread.joinable()) {
-    I().mInfoThread.join();
-  }
-
-  // clear all Stfs from the pipeline before the transport is deleted
-  if (mI) {
-    I().stopPipeline();
-    I().clearPipeline();
-    mI.reset();
-  }
-
-  // stop monitoring
-  DataDistMonitor::stop_datadist();
-}
+{ }
 
 void StfSenderDevice::Init()
 {
@@ -114,6 +96,23 @@ void StfSenderDevice::Init()
 
 void StfSenderDevice::Reset()
 {
+  DDDLOG("StfBuilderDevice::Reset()");
+
+  I().mDeviceRunning = false;
+  // wait the Info thread, before closing mTfSchedulerRpcClient
+  if (I().mInfoThread.joinable()) {
+    I().mInfoThread.join();
+  }
+
+  // clear all Stfs from the pipeline before the transport is deleted
+  if (mI) {
+    I().stopPipeline();
+    I().clearPipeline();
+    mI.reset();
+  }
+
+  // stop monitoring
+  DataDistMonitor::stop_datadist();
 }
 
 void StfSenderDevice::InitTask()
@@ -229,16 +228,16 @@ void StfSenderDevice::PostRun()
 
 void StfSenderDevice::ResetTask()
 {
-  // Stop the pipeline
-  I().stopPipeline();
-  I().clearPipeline();
-
   I().mRunning = false;
+
+    // Stop the pipeline
+  I().stopPipeline();
 
   // stop the receiver thread
   if (I().mReceiverThread.joinable()) {
     I().mReceiverThread.join();
   }
+  I().clearPipeline();
 
   // stop file sink
   if (I().mFileSink->enabled()) {

--- a/src/StfSender/StfSenderDevice.h
+++ b/src/StfSender/StfSenderDevice.h
@@ -101,6 +101,7 @@ class StfSenderDevice : public DataDistDevice
     bool mRunning = false;
     bool mDeviceRunning = true;
     bool mAcceptingData = false;
+    std::uint64_t mLastStfId = 0;
     std::thread mReceiverThread;
 
     /// File sink

--- a/src/StfSender/StfSenderOutput.h
+++ b/src/StfSender/StfSenderOutput.h
@@ -48,6 +48,7 @@ public:
   }
 
   void start(std::shared_ptr<ConsulStfSender> pDiscoveryConfig);
+  void register_regions();
   void start_standalone(std::shared_ptr<ConsulStfSender> pDiscoveryConfig);
   void stop();
 

--- a/src/TfBuilder/TfBuilderDevice.cxx
+++ b/src/TfBuilder/TfBuilderDevice.cxx
@@ -389,6 +389,8 @@ void TfBuilderDevice::TfForwardThread()
     }
 
     if (lTfOpt == std::nullopt) {
+      DDMON("tfbuilder", "tf_output.sent_size", mTfFwdTotalDataSize);
+      DDMON("tfbuilder", "tf_output.sent_count", mTfFwdTotalTfCount);
       continue;
     }
 

--- a/src/TfBuilder/TfBuilderRpc.cxx
+++ b/src/TfBuilder/TfBuilderRpc.cxx
@@ -224,7 +224,6 @@ void TfBuilderRpcImpl::UpdateSendingThread()
       sendTfBuilderUpdate();
       mUpdateCondition.wait_for(lLock, 500ms);
     } else {
-      stopAcceptingTfs();
       std::this_thread::sleep_for(1s);
     }
   }

--- a/src/common/base/DataDistLogger.h
+++ b/src/common/base/DataDistLogger.h
@@ -209,7 +209,7 @@ public:
 
         default:
           if (StdoutEnabled(mSeverity)) {
-            I().info("[???] " + std::string(mLogMessage.begin(), mLogMessage.end()));
+            I().info(std::string(mLogMessage.begin(), mLogMessage.end()));
           }
           break;
       }

--- a/src/common/rpc/StfSenderRpcClient.h
+++ b/src/common/rpc/StfSenderRpcClient.h
@@ -152,7 +152,7 @@ public:
   // rpc TerminatePartition(PartitionInfo) returns (PartitionResponse) { }
   bool TerminatePartition(const PartitionInfo &pPartInfo) {
     ClientContext lContext;
-    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(500));
+    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(1000));
 
     PartitionResponse lRet;
     mStub->TerminatePartition(&lContext, pPartInfo, &lRet);
@@ -228,7 +228,7 @@ public:
 
       StfSenderConfigStatus lStfSenderStatus;
       if (! mDiscoveryConfig->getStfSenderConfig(lPartId, lStfSenderId, lStfSenderStatus /*out*/)) {
-        DDDLOG("Missing StfSender configuration. Connection will be retried. stfs_id={}", lStfSenderId);
+        DDDLOG_RL(2000, "Missing StfSender configuration. Connection will be retried. stfs_id={}", lStfSenderId);
         continue;
       }
 

--- a/src/common/rpc/TfBuilderRpcClient.h
+++ b/src/common/rpc/TfBuilderRpcClient.h
@@ -117,7 +117,7 @@ public:
   bool TerminatePartition(const PartitionInfo &pPartitionInfo) {
     ClientContext lContext;
     // we don't care about the success. TfBuilder will be terminated by ECS
-    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(500));
+    lContext.set_deadline(std::chrono::system_clock::now() + std::chrono::milliseconds(1000));
 
     PartitionResponse lResponse;
     auto lStatus = mStub->TerminatePartition(&lContext, pPartitionInfo, &lResponse);


### PR DESCRIPTION
- tfscheduler: fix process lingering after termination request
- monitoring: make it easier to spot non-synchronized and stalled data flow on flps
- stfsender: start the grpc earlier in the configure procedure