### PR TITLE
DataDistribution v1.4.11

### DIFF
--- a/script/start_Discovery-3FLP-3EPN.sh
+++ b/script/start_Discovery-3FLP-3EPN.sh
@@ -160,6 +160,10 @@ STF_SENDER+=" --mq-config $chainConfig"
 STF_SENDER+=" --monitoring-interval=2.0"
 STF_SENDER+=" --monitoring-log"
 STF_SENDER+=" --shm-monitor=false"
+
+STF_SENDER+=" --dd-region-size=2048"
+STF_SENDER+=" --dd-region-id=666"
+
 if [[ $EPN_CNT -eq 0 ]]; then
   STF_SENDER+=" --stand-alone"
 fi
@@ -271,7 +275,7 @@ else
       split-window \
       "source $ENV_VAR_FILE; $STF_BUILDER --id stf_builder-0 --session default; read" \; \
       split-window  \
-      "source $ENV_VAR_FILE; $STF_SENDER --id stf_sender-0 --discovery-id=flp0 --session default; read" \; \
+      "source $ENV_VAR_FILE; numactl --cpunodebind=0 --preferred=0 -- $STF_SENDER --id stf_sender-0 --discovery-id=flp0 --session default; read" \; \
       split-window  \
       "source $ENV_VAR_FILE; numactl --interleave=all $TF_BUILDER --id tf_builder-0 --discovery-id=epn0 --session epn-s0; read" \; \
       select-layout even-horizontal
@@ -285,7 +289,7 @@ else
       split-window \
       "source $ENV_VAR_FILE; $STF_BUILDER --id stf_builder-1 --session flp-s1; read" \; \
       split-window  \
-      "source $ENV_VAR_FILE; $STF_SENDER --id stf_sender-1 --discovery-id=flp1 --session  flp-s1; read" \; \
+      "source $ENV_VAR_FILE; numactl --cpunodebind=0 --preferred=0 -- $STF_SENDER --id stf_sender-1 --discovery-id=flp1 --session  flp-s1; read" \; \
       select-layout even-horizontal
   fi
 

--- a/src/ReadoutEmulator/CruEmulator.cxx
+++ b/src/ReadoutEmulator/CruEmulator.cxx
@@ -13,7 +13,7 @@
 
 #include <ConcurrentQueue.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 
 #include <chrono>
 #include <thread>

--- a/src/ReadoutEmulator/CruMemoryHandler.cxx
+++ b/src/ReadoutEmulator/CruMemoryHandler.cxx
@@ -16,7 +16,7 @@
 
 #include <fairmq/FairMQUnmanagedRegion.h>
 #include <fairmq/FairMQDevice.h> /* NewUnmanagedRegionFor */
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 
 #include <chrono>
 #include <thread>

--- a/src/ReadoutEmulator/ReadoutDevice.cxx
+++ b/src/ReadoutEmulator/ReadoutDevice.cxx
@@ -15,7 +15,7 @@
 
 #include <MemoryUtils.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 
 #include <chrono>
 #include <thread>

--- a/src/ReadoutEmulator/ReadoutDevice.h
+++ b/src/ReadoutEmulator/ReadoutDevice.h
@@ -79,7 +79,7 @@ class ReadoutDevice : public DataDistDevice
   std::vector<std::unique_ptr<CruLinkEmulator>> mCruLinks;
 
   // messages to send
-  std::vector<FairMQMessagePtr> mDataBlockMsgs;
+  std::vector<fair::mq::MessagePtr> mDataBlockMsgs;
   std::thread mSendingThread;
 
   /// Observables

--- a/src/ReadoutEmulator/runReadoutEmulatorDevice.cxx
+++ b/src/ReadoutEmulator/runReadoutEmulatorDevice.cxx
@@ -10,7 +10,7 @@
 
 #include "ReadoutDevice.h"
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 
 #include "runFairMQDevice.h"
 
@@ -43,7 +43,7 @@ void addCustomOptions(bpo::options_description& options)
     "Input throughput per link (bits per second).");
 }
 
-FairMQDevicePtr getDevice(const FairMQProgOptions& /*config*/)
+FairMQDevicePtr getDevice(const fair::mq::ProgOptions& /*config*/)
 {
   return new o2::DataDistribution::ReadoutDevice();
 }

--- a/src/StfBuilder/StfBuilderDevice.cxx
+++ b/src/StfBuilder/StfBuilderDevice.cxx
@@ -90,6 +90,12 @@ void StfBuilderDevice::InitTask()
 {
   DataDistLogger::SetThreadName("stfb-main");
 
+  Transport()->SubscribeToRegionEvents([this](fair::mq::RegionInfo info) {
+    if (fair::mq::RegionEvent::created == info.event) {
+      DDDLOG("Region created. size={} managed={}", info.size, info.managed);
+    }
+  });
+
   I().mInputChannelName = GetConfig()->GetValue<std::string>(OptionKeyInputChannelName);
   I().mOutputChannelName = GetConfig()->GetValue<std::string>(OptionKeyOutputChannelName);
   I().mDplChannelName = GetConfig()->GetValue<std::string>(OptionKeyDplChannelName);
@@ -290,6 +296,8 @@ void StfBuilderDevice::InitTask()
 void StfBuilderDevice::ResetTask()
 {
   DDDLOG("StfBuilderDevice::ResetTask()");
+
+  Transport()->UnsubscribeFromRegionEvents();
 
   // Signal ConditionalRun() and other threads to stop
   I().mState.mRunning = false;

--- a/src/StfBuilder/StfBuilderDevice.cxx
+++ b/src/StfBuilder/StfBuilderDevice.cxx
@@ -23,7 +23,7 @@
 
 #include <Headers/DataHeader.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 
 #include <chrono>
 #include <thread>

--- a/src/StfBuilder/StfBuilderInput.cxx
+++ b/src/StfBuilder/StfBuilderInput.cxx
@@ -37,7 +37,7 @@ void StfInputInterface::start(bool pBuildStf, std::shared_ptr<ConsulStfBuilder> 
   mBuildStf = pBuildStf;
   mDiscoveryConfig = pStfBuilderConfig;
 
-  mBuilderInputQueue = std::make_unique<ConcurrentFifo<std::vector<FairMQMessagePtr>>>();
+  mBuilderInputQueue = std::make_unique<ConcurrentFifo<std::vector<fair::mq::MessagePtr>>>();
   mStfBuilder = std::make_unique<SubTimeFrameReadoutBuilder>(mDevice.MemI());
 
   // sequence thread only needed when building physics STFs
@@ -87,7 +87,7 @@ mRunning = false;
 void StfInputInterface::StfReceiverThread()
 {
   using namespace std::chrono_literals;
-  std::vector<FairMQMessagePtr> lReadoutMsgs;
+  std::vector<fair::mq::MessagePtr> lReadoutMsgs;
   lReadoutMsgs.reserve(4096);
 
   // Reference to the input channel
@@ -191,7 +191,7 @@ void StfInputInterface::StfBuilderThread()
   using namespace std::chrono_literals;
 
   bool lStarted = false;
-  std::vector<FairMQMessagePtr> lReadoutMsgs;
+  std::vector<fair::mq::MessagePtr> lReadoutMsgs;
   lReadoutMsgs.reserve(1U << 20);
 
   // support FEEID masking
@@ -217,7 +217,7 @@ void StfInputInterface::StfBuilderThread()
   // insert and mask the feeid
   auto lInsertWithFeeIdMasking = [&lStfBuilder, lFeeIdMask] (const header::DataOrigin &pDataOrigin,
     const header::DataHeader::SubSpecificationType &pSubSpec, const ReadoutSubTimeframeHeader &pRdoHeader,
-    const FairMQParts::iterator pStartHbf, const std::size_t pInsertCnt) {
+    const fair::mq::Parts::iterator pStartHbf, const std::size_t pInsertCnt) {
 
     // mask the subspecification if the fee mode is used
     auto lMaskedSubspec = pSubSpec;
@@ -402,7 +402,7 @@ void StfInputInterface::TopologicalStfBuilderThread()
   using namespace std::chrono_literals;
 
   bool lStarted = false;
-  std::vector<FairMQMessagePtr> lReadoutMsgs(1U << 20);
+  std::vector<fair::mq::MessagePtr> lReadoutMsgs(1U << 20);
   lReadoutMsgs.clear();
 
   // per equipment data cache
@@ -447,7 +447,7 @@ void StfInputInterface::TopologicalStfBuilderThread()
     const header::DataOrigin &pDataOrigin,
     const header::DataHeader::SubSpecificationType &pSubSpec,
     const ReadoutSubTimeframeHeader &pRdoHeader,
-    FairMQParts::iterator &pStartHbf /* in/out */,
+    fair::mq::Parts::iterator &pStartHbf /* in/out */,
     std::size_t &pInsertCnt /* in/out */) -> std::optional<std::unique_ptr<SubTimeFrame> > {
 
     // mask the subspecification if the fee mode is used

--- a/src/StfBuilder/StfBuilderInput.h
+++ b/src/StfBuilder/StfBuilderInput.h
@@ -77,7 +77,7 @@ public:
   std::thread mInputThread;
 
   /// StfBuilding thread and queues
-  std::unique_ptr<ConcurrentFifo<std::vector<FairMQMessagePtr>>> mBuilderInputQueue = nullptr;
+  std::unique_ptr<ConcurrentFifo<std::vector<fair::mq::MessagePtr>>> mBuilderInputQueue = nullptr;
   std::unique_ptr<SubTimeFrameReadoutBuilder> mStfBuilder = nullptr;
   std::uint32_t mStfIdBuilding = 0;
   std::thread mBuilderThread;

--- a/src/StfBuilder/runStfBuilderDevice.cxx
+++ b/src/StfBuilder/runStfBuilderDevice.cxx
@@ -12,7 +12,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "StfBuilderDevice.h"
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 #include <grpc/grpc.h>
 
 #include <SubTimeFrameFileSink.h>

--- a/src/StfSender/StfSenderDevice.cxx
+++ b/src/StfSender/StfSenderDevice.cxx
@@ -19,7 +19,7 @@
 #include <SubTimeFrameVisitors.h>
 #include <SubTimeFrameDPL.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 
 #include <chrono>
 #include <thread>
@@ -88,8 +88,6 @@ void StfSenderDevice::Init()
   I().mStandalone = GetConfig()->GetValue<bool>(OptionKeyStandalone);
 
   I().mFileSink = std::make_unique<SubTimeFrameFileSink>(*this, *mI, eFileSinkIn, eFileSinkOut);
-
-  I().mStandalone = GetConfig()->GetValue<bool>(OptionKeyStandalone);
 
   I().mPartitionId = Config::getPartitionOption(*GetConfig()).value_or("");
   if (I().mPartitionId.empty()) {

--- a/src/StfSender/StfSenderDevice.h
+++ b/src/StfSender/StfSenderDevice.h
@@ -53,6 +53,8 @@ class StfSenderDevice : public DataDistDevice
  public:
   static constexpr const char* OptionKeyInputChannelName = "input-channel-name";
   static constexpr const char* OptionKeyStandalone = "stand-alone";
+  static constexpr const char* OptionKeyDataRegionSize = "dd-region-size";
+  static constexpr const char* OptionKeyDataRegionId = "dd-region-id";
 
   /// Default constructor
   StfSenderDevice();
@@ -97,6 +99,10 @@ class StfSenderDevice : public DataDistDevice
     /// Scheduler RPC client
     TfSchedulerRpcClient mTfSchedulerRpcClient;
 
+    /// StfCopy region
+    std::uint64_t mDataRegionSize = std::uint64_t(32) << 30;
+    std::optional<std::uint16_t> mDataRegionId = std::nullopt;
+
     /// Receiver threads
     bool mRunning = false;
     bool mDeviceRunning = true;
@@ -106,6 +112,9 @@ class StfSenderDevice : public DataDistDevice
 
     /// File sink
     std::unique_ptr<SubTimeFrameFileSink> mFileSink;
+
+    /// StfCopy builder
+    std::shared_ptr<SubTimeFrameCopyBuilder> mStfCopyBuilder;
 
     /// Output stage handler
     std::unique_ptr<StfSenderOutput> mOutputHandler;
@@ -152,10 +161,12 @@ class StfSenderDevice : public DataDistDevice
   };
 
   std::unique_ptr<StfSenderInstance> mI;
+  std::unique_ptr<SyncMemoryResources> mMemI;
   const StfSenderInstance& I() const { return *mI; }
 
 public:
   StfSenderInstance& I() { return *mI; }
+  SyncMemoryResources& MemI() { return *mMemI; }
 };
 
 } /* namespace o2::DataDistribution */

--- a/src/StfSender/StfSenderDevice.h
+++ b/src/StfSender/StfSenderDevice.h
@@ -130,7 +130,6 @@ class StfSenderDevice : public DataDistDevice
       StfSenderPipeline lNextStage = eInvalidStage;
       switch (pStage) {
         case eReceiverOut:
-        /*  case eFileSinkOut: */
         {
           if (mFileSink->enabled()) {
             lNextStage = eFileSinkIn;
@@ -142,11 +141,6 @@ class StfSenderDevice : public DataDistDevice
         }
         case eFileSinkOut:
         {
-          if (mStandalone) {
-            lNextStage = eNullIn;
-            break;
-          }
-
           lNextStage = eSenderIn;
           break;
         }

--- a/src/StfSender/StfSenderOutput.cxx
+++ b/src/StfSender/StfSenderOutput.cxx
@@ -56,7 +56,7 @@ void StfSenderOutput::start(std::shared_ptr<ConsulStfSender> pDiscoveryConfig)
   if (lTransportOpt == "fmq" || lTransportOpt == "FMQ" || lTransportOpt == "fairmq" || lTransportOpt == "FAIRMQ") {
     // create a socket and connect
     mDevice.GetConfig()->SetProperty<int>("io-threads", (int) std::min(std::thread::hardware_concurrency(), 20u));
-    mZMQTransportFactory = FairMQTransportFactory::CreateTransportFactory("zeromq", "", mDevice.GetConfig());
+    mZMQTransportFactory = fair::mq::TransportFactory::CreateTransportFactory("zeromq", "", mDevice.GetConfig());
 
     // create FairMQ output
     mOutputFairMQ = std::make_unique<StfSenderOutputFairMQ>(pDiscoveryConfig, mCounters);

--- a/src/StfSender/StfSenderOutput.h
+++ b/src/StfSender/StfSenderOutput.h
@@ -122,7 +122,7 @@ public:
 
   /// Discovery configuration
   std::shared_ptr<ConsulStfSender> mDiscoveryConfig;
-  std::shared_ptr<FairMQTransportFactory> mZMQTransportFactory;
+  std::shared_ptr<fair::mq::TransportFactory> mZMQTransportFactory;
 
   /// StfCopy builder; not used if nullptr
   std::shared_ptr<SubTimeFrameCopyBuilder> mStfCopyBuilder;

--- a/src/StfSender/StfSenderOutputFairMQ.cxx
+++ b/src/StfSender/StfSenderOutputFairMQ.cxx
@@ -21,7 +21,7 @@ namespace o2::DataDistribution
 
 using namespace std::chrono_literals;
 
-void StfSenderOutputFairMQ::start(std::shared_ptr<FairMQTransportFactory> pZMQTransportFactory)
+void StfSenderOutputFairMQ::start(std::shared_ptr<fair::mq::TransportFactory> pZMQTransportFactory)
 {
   mZMQTransportFactory = pZMQTransportFactory;
   mRunning = true;
@@ -63,7 +63,7 @@ ConnectStatus StfSenderOutputFairMQ::connectTfBuilder(const std::string &pTfBuil
   auto lChanName = "tf_builder_" + pTfBuilderId;
   std::replace(lChanName.begin(), lChanName.end(),'.', '_');
 
-  auto lNewChannel = std::make_unique<FairMQChannel>(
+  auto lNewChannel = std::make_unique<fair::mq::Channel>(
     lChanName ,              // name
     "push",                  // type
     "connect",               // method

--- a/src/StfSender/StfSenderOutputFairMQ.h
+++ b/src/StfSender/StfSenderOutputFairMQ.h
@@ -38,7 +38,7 @@ public:
 
   }
 
-  void start(std::shared_ptr<FairMQTransportFactory> pZMQTransportFactory);
+  void start(std::shared_ptr<fair::mq::TransportFactory> pZMQTransportFactory);
   void stop();
 
   /// RPC requests
@@ -56,7 +56,7 @@ private:
 
   /// Discovery configuration
   std::shared_ptr<ConsulStfSender> mDiscoveryConfig;
-  std::shared_ptr<FairMQTransportFactory>  mZMQTransportFactory;
+  std::shared_ptr<fair::mq::TransportFactory>  mZMQTransportFactory;
 
   // Global stf counters
   StdSenderOutputCounters &mCounters;
@@ -64,7 +64,7 @@ private:
   /// Threads for output channels (to EPNs)
   struct OutputChannelObjects {
     std::string mTfBuilderEndpoint;
-    std::unique_ptr<FairMQChannel> mChannel;
+    std::unique_ptr<fair::mq::Channel> mChannel;
     std::unique_ptr<IovSerializer> mStfSerializer;
     std::unique_ptr<ConcurrentFifo<std::unique_ptr<SubTimeFrame>>> mStfQueue;
     std::thread mThread;

--- a/src/StfSender/runStfSenderDevice.cxx
+++ b/src/StfSender/runStfSenderDevice.cxx
@@ -15,7 +15,7 @@
 #include <FmqUtilities.h>
 #include <DataDistMonitoring.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 #include <grpc/grpc.h>
 
 namespace bpo = boost::program_options;

--- a/src/StfSender/runStfSenderDevice.cxx
+++ b/src/StfSender/runStfSenderDevice.cxx
@@ -52,7 +52,13 @@ int main(int argc, char* argv[])
         "Name of the input STF channel")(
         o2::DataDistribution::StfSenderDevice::OptionKeyStandalone,
         bpo::bool_switch()->default_value(false),
-        "Standalone operation. SubTimeFrames will not be forwarded to other processes.");
+        "Standalone operation. SubTimeFrames will not be forwarded to other processes.")(
+        o2::DataDistribution::StfSenderDevice::OptionKeyDataRegionSize,
+        bpo::value<std::uint64_t>()->default_value(32768),
+        "Memory buffer (shm region) reserved for SubTimeFrames in sending (in MiB).")(
+        o2::DataDistribution::StfSenderDevice::OptionKeyDataRegionId,
+        bpo::value<std::uint16_t>()->default_value(std::uint16_t(~0)),
+        "Optional shm id for reusing existing regions. (default will create a new region)");
 
       r.fConfig.AddToCmdLineOptions(lStfSenderOptions);
 

--- a/src/StfSender/runStfSenderDevice.cxx
+++ b/src/StfSender/runStfSenderDevice.cxx
@@ -54,8 +54,8 @@ int main(int argc, char* argv[])
         bpo::bool_switch()->default_value(false),
         "Standalone operation. SubTimeFrames will not be forwarded to other processes.")(
         o2::DataDistribution::StfSenderDevice::OptionKeyDataRegionSize,
-        bpo::value<std::uint64_t>()->default_value(32768),
-        "Memory buffer (shm region) reserved for SubTimeFrames in sending (in MiB).")(
+        bpo::value<std::uint64_t>()->default_value(0),
+        "Memory buffer (shm region) reserved for SubTimeFrames in sending (in MiB). If set ot 0, no data copying will take place.")(
         o2::DataDistribution::StfSenderDevice::OptionKeyDataRegionId,
         bpo::value<std::uint16_t>()->default_value(std::uint16_t(~0)),
         "Optional shm id for reusing existing regions. (default will create a new region)");

--- a/src/TfBuilder/TfBuilderInput.cxx
+++ b/src/TfBuilder/TfBuilderInput.cxx
@@ -56,7 +56,7 @@ bool TfBuilderInput::start()
 {
   // make max number of listening channels for the partition
   mDevice.GetConfig()->SetProperty<int>("io-threads", (int) std::min(std::thread::hardware_concurrency(), 32u));
-  auto lTransportFactory = FairMQTransportFactory::CreateTransportFactory("zeromq", "", mDevice.GetConfig());
+  auto lTransportFactory = fair::mq::TransportFactory::CreateTransportFactory("zeromq", "", mDevice.GetConfig());
 
   // start the input stage
   if (mInputFairMQ) {

--- a/src/TfBuilder/TfBuilderInput.cxx
+++ b/src/TfBuilder/TfBuilderInput.cxx
@@ -238,9 +238,6 @@ void TfBuilderInput::deserialize_headers(std::vector<ReceivedStfMeta> &pStfs)
 /// This thread can block waiting on free O2 Header memory
 void TfBuilderInput::StfDeserializingThread()
 {
-  // Deserialization object
-  IovDeserializer lStfReceiver(mDevice.TfBuilderI());
-
   while (mState == RUNNING) {
 
     std::unique_lock<std::mutex> lQueueLock(mStfMergerQueueLock);

--- a/src/TfBuilder/TfBuilderInput.h
+++ b/src/TfBuilder/TfBuilderInput.h
@@ -23,6 +23,7 @@
 
 #include <SubTimeFrameDataModel.h>
 #include <ConcurrentQueue.h>
+#include <MemoryUtils.h>
 
 #include <vector>
 #include <map>

--- a/src/TfBuilder/TfBuilderInputDefs.h
+++ b/src/TfBuilder/TfBuilderInputDefs.h
@@ -34,7 +34,7 @@ struct ReceivedStfMeta {
     std::chrono::time_point<std::chrono::steady_clock> mTimeReceived;
 
     std::unique_ptr<IovStfHdrMeta> mRecvStfHeaderMeta;
-    std::unique_ptr<std::vector<FairMQMessagePtr>> mRecvStfData;
+    std::unique_ptr<std::vector<fair::mq::MessagePtr>> mRecvStfData;
     std::unique_ptr<SubTimeFrame> mStf;
     std::string mStfSenderId;
 
@@ -47,7 +47,7 @@ struct ReceivedStfMeta {
                     const SubTimeFrame::Header::Origin pStfOrigin,
                     const std::string &pStfSenderId,
                     std::unique_ptr<IovStfHdrMeta> &&pRcvHdrMeta,
-                    std::unique_ptr<std::vector<FairMQMessagePtr>> &&pRecvStfData)
+                    std::unique_ptr<std::vector<fair::mq::MessagePtr>> &&pRecvStfData)
     : mType(INFO),
       mStfId(pStfId),
       mStfOrigin(pStfOrigin),

--- a/src/TfBuilder/TfBuilderInputFairMQ.cxx
+++ b/src/TfBuilder/TfBuilderInputFairMQ.cxx
@@ -32,7 +32,7 @@ namespace o2::DataDistribution
 
 using namespace std::chrono_literals;
 
-bool TfBuilderInputFairMQ::start(std::shared_ptr<ConsulTfBuilder> pConfig, std::shared_ptr<FairMQTransportFactory> pZMQTransportFactory)
+bool TfBuilderInputFairMQ::start(std::shared_ptr<ConsulTfBuilder> pConfig, std::shared_ptr<fair::mq::TransportFactory> pZMQTransportFactory)
 {
   auto &lStatus = pConfig->status();
 
@@ -77,7 +77,7 @@ bool TfBuilderInputFairMQ::start(std::shared_ptr<ConsulTfBuilder> pConfig, std::
 
     std::string lAddress = "tcp://" + lAaddress + ":" + std::to_string(10000 + lSocketIdx);
 
-    auto lNewChannel = std::make_unique<FairMQChannel>(
+    auto lNewChannel = std::make_unique<fair::mq::Channel>(
       "stf_sender_chan_" + std::to_string(lSocketIdx) ,  // name
       "pull",               // type
       "bind",               // method
@@ -244,10 +244,10 @@ void TfBuilderInputFairMQ::DataHandlerThread(const std::uint32_t pFlpIndex, cons
 
   while (mState == RUNNING) {
 
-    std::unique_ptr<std::vector<FairMQMessagePtr>> lStfData;
+    std::unique_ptr<std::vector<fair::mq::MessagePtr>> lStfData;
 
 
-    lStfData = std::make_unique<std::vector<FairMQMessagePtr>>();
+    lStfData = std::make_unique<std::vector<fair::mq::MessagePtr>>();
 
     const std::int64_t lRet = lInputChan.Receive(*lStfData, 1000 /* ms */);
     if (static_cast<std::int64_t>(fair::mq::TransferCode::timeout) == lRet) {
@@ -269,7 +269,7 @@ void TfBuilderInputFairMQ::DataHandlerThread(const std::uint32_t pFlpIndex, cons
     }
 
     // get Stf ID
-    FairMQMessagePtr lHdrMessage = std::move(lStfData->back()); lStfData->pop_back();
+    fair::mq::MessagePtr lHdrMessage = std::move(lStfData->back()); lStfData->pop_back();
 
     IovStfHeader lStfHeaderMeta;
     lStfHeaderMeta.ParseFromArray(lHdrMessage->GetData(), lHdrMessage->GetSize());

--- a/src/TfBuilder/TfBuilderInputFairMQ.h
+++ b/src/TfBuilder/TfBuilderInputFairMQ.h
@@ -47,7 +47,7 @@ class TfBuilderInputFairMQ
     mStfReqQueue.stop(); // not used in FMQ transport
   }
 
-  bool start(std::shared_ptr<ConsulTfBuilder> pConfig, std::shared_ptr<FairMQTransportFactory> pZMQTransportFactory);
+  bool start(std::shared_ptr<ConsulTfBuilder> pConfig, std::shared_ptr<fair::mq::TransportFactory> pZMQTransportFactory);
   void stop(std::shared_ptr<ConsulTfBuilder> pConfig);
   void reset() { }
 
@@ -66,7 +66,7 @@ class TfBuilderInputFairMQ
   std::uint32_t mNumStfSenders = 0;
 
   /// StfBuilder channels
-  std::vector<std::unique_ptr<FairMQChannel>> mStfSenderChannels;
+  std::vector<std::unique_ptr<fair::mq::Channel>> mStfSenderChannels;
 
   /// Threads for input channels (per FLP)
   std::map<std::string, std::thread> mInputThreads;

--- a/src/TfBuilder/TfBuilderInputUCX.cxx
+++ b/src/TfBuilder/TfBuilderInputUCX.cxx
@@ -738,7 +738,7 @@ void TfBuilderInputUCX::DataHandlerThread(const unsigned pThreadIdx)
 
   // memory for meta-tag receive
   const std::uint64_t lMetaMemSize = 128;
-  FairMQMessagePtr lMetaMemMsg = mTimeFrameBuilder.newDataMessage(lMetaMemSize);
+  fair::mq::MessagePtr lMetaMemMsg = mTimeFrameBuilder.newDataMessage(lMetaMemSize);
   void *lMetaMemPtr = mTimeFrameBuilder.mMemRes.mDataMemRes->get_ucx_ptr(lMetaMemMsg->GetData());
 
   // local worker we advance here
@@ -880,7 +880,7 @@ void TfBuilderInputUCX::StfPostprocessThread(const unsigned pThreadIdx)
 
     // create fmq messages from txgs
     lDataMsgsBuffers.clear();
-    auto lDataVec = std::make_unique<std::vector<FairMQMessagePtr> >();
+    auto lDataVec = std::make_unique<std::vector<fair::mq::MessagePtr> >();
     lDataVec->reserve(lStfMeta.stf_data_iov_size());
 
     for (const auto &lDataMsg : lStfMeta.stf_data_iov()) {

--- a/src/TfBuilder/TfBuilderInputUCX.cxx
+++ b/src/TfBuilder/TfBuilderInputUCX.cxx
@@ -735,8 +735,6 @@ void TfBuilderInputUCX::DataHandlerThread(const unsigned pThreadIdx)
   using clock = std::chrono::steady_clock;
 
   DDDLOG("Starting receiver thread[{}]", pThreadIdx);
-  // Deserialization object (stf ID)
-  IovDeserializer lStfReceiver(mTimeFrameBuilder);
 
   // memory for meta-tag receive
   const std::uint64_t lMetaMemSize = 128;

--- a/src/TfBuilder/runTfBuilderDevice.cxx
+++ b/src/TfBuilder/runTfBuilderDevice.cxx
@@ -19,7 +19,7 @@
 #include <Config.h>
 #include <FmqUtilities.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 #include <fairmq/DeviceRunner.h>
 #include <grpc/grpc.h>
 

--- a/src/TfScheduler/TfSchedulerDevice.cxx
+++ b/src/TfScheduler/TfSchedulerDevice.cxx
@@ -17,7 +17,7 @@
 
 #include <ConfigConsul.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 
 #include <chrono>
 #include <thread>

--- a/src/TfScheduler/runTfScheduler.cxx
+++ b/src/TfScheduler/runTfScheduler.cxx
@@ -14,7 +14,7 @@
 #include <Config.h>
 #include <FmqUtilities.h>
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 #include <fairmq/DeviceRunner.h>
 #include <grpc/grpc.h>
 

--- a/src/common/ReadoutDataModel.cxx
+++ b/src/common/ReadoutDataModel.cxx
@@ -73,7 +73,7 @@ ReadoutDataUtils::getSubSpecification(const RDHReader &R)
 }
 
 std::tuple<std::size_t, bool>
-ReadoutDataUtils::getHBFrameMemorySize(const FairMQMessagePtr &pMsg)
+ReadoutDataUtils::getHBFrameMemorySize(const fair::mq::MessagePtr &pMsg)
 {
   std::size_t lMemRet = 0;
   bool lStopRet = false;

--- a/src/common/ReadoutDataModel.h
+++ b/src/common/ReadoutDataModel.h
@@ -242,7 +242,7 @@ public:
     mRDHSize = sRDHReader->CheckRdhData(mData, mSize);
   }
 
-  explicit RDHReader(const FairMQMessagePtr &msg) {
+  explicit RDHReader(const fair::mq::MessagePtr &msg) {
     if (!msg) {
       throw std::runtime_error("RDHReader::msg is null");
     }
@@ -405,7 +405,7 @@ public:
   static o2::header::DataOrigin getDataOrigin(const RDHReader &R);
   static o2::header::DataHeader::SubSpecificationType getSubSpecification(const RDHReader &R);
 
-  static std::tuple<std::size_t, bool> getHBFrameMemorySize(const FairMQMessagePtr &pMsg);
+  static std::tuple<std::size_t, bool> getHBFrameMemorySize(const fair::mq::MessagePtr &pMsg);
 
   static bool rdhSanityCheck(const char* data, const std::size_t len);
   static bool filterEmptyTriggerBlocks(const char* pData, const std::size_t pLen);

--- a/src/common/SubTimeFrameBuilder.cxx
+++ b/src/common/SubTimeFrameBuilder.cxx
@@ -53,7 +53,7 @@ bool SubTimeFrameReadoutBuilder::addHbFrames(
   const o2::header::DataOrigin &pDataOrig,
   const o2::header::DataHeader::SubSpecificationType pSubSpecification,
   const ReadoutSubTimeframeHeader& pHdr,
-  std::vector<FairMQMessagePtr>::iterator pHbFramesBegin, const std::size_t pHBFrameLen)
+  std::vector<fair::mq::MessagePtr>::iterator pHbFramesBegin, const std::size_t pHBFrameLen)
 {
   static thread_local std::vector<bool> lRemoveBlocks;
 
@@ -181,7 +181,7 @@ bool SubTimeFrameReadoutBuilder::addHbFrames(
   const o2hdr::DataIdentifier lDataId(o2::header::gDataDescriptionRawData.str,  pDataOrig.str);
 
   // Speed up adding messages by saving the vector of split-payloads
-  std::vector<FairMQMessagePtr> *pInVector = nullptr;
+  std::vector<fair::mq::MessagePtr> *pInVector = nullptr;
 
   for (size_t i = 0; i < pHBFrameLen; i++) {
 
@@ -222,12 +222,12 @@ std::optional<std::unique_ptr<SubTimeFrame>> SubTimeFrameReadoutBuilder::addTopo
   const o2::header::DataOrigin &pDataOrig,
   const o2::header::DataHeader::SubSpecificationType pSubSpecification,
   const ReadoutSubTimeframeHeader& pHdr,
-  std::vector<FairMQMessagePtr>::iterator &pHbFramesBegin, std::size_t &pHBFrameLen,
+  std::vector<fair::mq::MessagePtr>::iterator &pHbFramesBegin, std::size_t &pHBFrameLen,
   const std::uint64_t pMaxNumMessages, bool pCutTfOnNewOrbit)
 {
   static uint32_t sTfId = 1;
 
-  auto isFirstPacketOfOrbit = [&](const FairMQMessagePtr &pMsg) -> bool {
+  auto isFirstPacketOfOrbit = [&](const fair::mq::MessagePtr &pMsg) -> bool {
     if (!pMsg) {
       return false;
     }
@@ -455,7 +455,7 @@ void TimeFrameBuilder::allocate_memory(const std::size_t pDataSegSize, const std
   mMemRes.start();
 }
 
-FairMQMessagePtr TimeFrameBuilder::newHeaderMessage(const char *pData, const std::size_t pSize)
+fair::mq::MessagePtr TimeFrameBuilder::newHeaderMessage(const char *pData, const std::size_t pSize)
 {
     if (pSize < sizeof (DataHeader)) {
       EDDLOG_RL(1000, "TimeFrameBuilder: Header size less that DataHeader size={}", pSize);

--- a/src/common/SubTimeFrameBuilder.cxx
+++ b/src/common/SubTimeFrameBuilder.cxx
@@ -40,7 +40,7 @@ SubTimeFrameReadoutBuilder::SubTimeFrameReadoutBuilder(SyncMemoryResources &pMem
 {
   mMemRes.mHeaderMemRes = std::make_unique<HeaderRegionAllocatorResource>(
     "O2HeadersRegion",
-    std::nullopt, std::size_t(512) << 20,
+    std::nullopt, std::size_t(128) << 20,
     *mMemRes.mShmTransport,
     0, /* region flags ? */
     true /* Header alloc can fail with large FLP-DPL backpreassure  */

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -43,12 +43,12 @@ class SubTimeFrameReadoutBuilder
   bool addHbFrames(const o2::header::DataOrigin &pDataOrig,
     const o2::header::DataHeader::SubSpecificationType pSubSpecification,
     const ReadoutSubTimeframeHeader& pHdr,
-    std::vector<FairMQMessagePtr>::iterator pHbFramesBegin, const std::size_t pHBFrameLen);
+    std::vector<fair::mq::MessagePtr>::iterator pHbFramesBegin, const std::size_t pHBFrameLen);
 
   std::optional<std::unique_ptr<SubTimeFrame>> addTopoStfData(const o2::header::DataOrigin &pDataOrig,
     const o2::header::DataHeader::SubSpecificationType pSubSpecification,
     const ReadoutSubTimeframeHeader& pHdr,
-    std::vector<FairMQMessagePtr>::iterator &pHbFramesBegin, std::size_t &pHBFrameLen,
+    std::vector<fair::mq::MessagePtr>::iterator &pHbFramesBegin, std::size_t &pHBFrameLen,
     const std::uint64_t pMaxNumMessages, bool pCutTfOnNewOrbit);
 
   std::optional<std::uint32_t> getCurrentStfId() const {
@@ -124,25 +124,18 @@ class SubTimeFrameFileBuilder
 
   // allocate appropriate message for the header
   inline
-  FairMQMessagePtr newHeaderMessage(const o2::header::Stack &pIncomingStack, const std::uint64_t pTfId) {
-    std::unique_ptr<FairMQMessage> lMsg;
-
+  fair::mq::MessagePtr newHeaderMessage(const o2::header::Stack &pIncomingStack, const std::uint64_t pTfId) {
     auto lStack = o2::header::Stack(
       pIncomingStack,
       o2::framework::DataProcessingHeader{pTfId}
     );
 
-    lMsg = mMemRes.newHeaderMessage(lStack.data(), lStack.size());
-    if (!lMsg) {
-      return nullptr;
-    }
-
-    return lMsg;
+    return mMemRes.newHeaderMessage(lStack.data(), lStack.size());
   }
 
   // allocate appropriate message for the data blocks
   inline
-  FairMQMessagePtr newDataMessage(const std::size_t pSize) {
+  fair::mq::MessagePtr newDataMessage(const std::size_t pSize) {
     return mMemRes.newDataMessage(pSize);
   }
 
@@ -171,20 +164,20 @@ class TimeFrameBuilder
   void adaptHeaders(SubTimeFrame *pStf);
 
 
-  FairMQMessagePtr newHeaderMessage(const char *pData, const std::size_t pSize);
+  fair::mq::MessagePtr newHeaderMessage(const char *pData, const std::size_t pSize);
 
   inline
-  FairMQMessagePtr newDataMessage(const std::size_t pSize) {
+  fair::mq::MessagePtr newDataMessage(const std::size_t pSize) {
     return mMemRes.newDataMessage(pSize);
   }
 
   inline
-  FairMQMessagePtr newDataMessage(const char *pData, const std::size_t pSize) {
+  fair::mq::MessagePtr newDataMessage(const char *pData, const std::size_t pSize) {
     return mMemRes.newDataMessage(pData, pSize);
   }
 
   inline
-  bool replaceDataMessages(std::vector<FairMQMessagePtr> &pMsgs) {
+  bool replaceDataMessages(std::vector<fair::mq::MessagePtr> &pMsgs) {
     return mMemRes.replaceDataMessages(pMsgs);
   }
 
@@ -199,11 +192,11 @@ class TimeFrameBuilder
     mMemRes.allocDataBuffers(pTxgSizes, std::back_inserter(pTxgPtrs));
   }
 
-  inline void allocHeaderMsgs(const std::vector<uint64_t> &pTxgSizes, std::vector<FairMQMessagePtr> &pHdrVec) {
+  inline void allocHeaderMsgs(const std::vector<uint64_t> &pTxgSizes, std::vector<fair::mq::MessagePtr> &pHdrVec) {
     mMemRes.allocHdrBuffers(pTxgSizes, std::back_inserter(pHdrVec));
   }
 
-  inline void newDataFmqMessagesFromPtr(const std::vector<std::pair<void*, std::size_t>> &pPtrSizes, std::vector<FairMQMessagePtr> &pDataVec) {
+  inline void newDataFmqMessagesFromPtr(const std::vector<std::pair<void*, std::size_t>> &pPtrSizes, std::vector<fair::mq::MessagePtr> &pDataVec) {
     mMemRes.fmqFromDataBuffers(pPtrSizes, std::back_inserter(pDataVec));
   }
 

--- a/src/common/SubTimeFrameBuilder.h
+++ b/src/common/SubTimeFrameBuilder.h
@@ -164,7 +164,7 @@ class TimeFrameBuilder
   TimeFrameBuilder() = delete;
   TimeFrameBuilder(SyncMemoryResources &pMemRes);
 
-  // make allocate the memory here
+  // allocate the memory here
   void allocate_memory(const std::size_t pDataSegSize, const std::optional<std::uint16_t> pDataSegId,
                        const std::size_t pHdrSegSize, const std::optional<std::uint16_t> pHdrSegId);
 
@@ -184,8 +184,8 @@ class TimeFrameBuilder
   }
 
   inline
-  void newDataMessages(const std::vector<FairMQMessagePtr> &pSrcMsgs, std::vector<FairMQMessagePtr> &pDstMsgs) {
-    mMemRes.newDataMessages(pSrcMsgs, pDstMsgs);
+  bool replaceDataMessages(std::vector<FairMQMessagePtr> &pMsgs) {
+    return mMemRes.replaceDataMessages(pMsgs);
   }
 
   inline void stop() {
@@ -209,6 +209,35 @@ class TimeFrameBuilder
 
   SyncMemoryResources &mMemRes;
 };
+
+
+////////////////////////////////////////////////////////////////////////////////
+/// SubTimeFrameCopyBuilder
+////////////////////////////////////////////////////////////////////////////////
+
+class SubTimeFrameCopyBuilder
+{
+ public:
+  SubTimeFrameCopyBuilder() = delete;
+  SubTimeFrameCopyBuilder(SyncMemoryResources &pMemRes)
+  : mMemRes(pMemRes)
+  { }
+
+  // make allocate the memory here
+  void allocate_memory(const std::size_t pDataSegSize, const std::optional<std::uint16_t> pDataSegId);
+
+  bool copyStfData(std::unique_ptr<SubTimeFrame> &pStf);
+
+  inline auto freeData() const { return mMemRes.freeData(); }
+
+  inline void stop() {
+    mMemRes.stop();
+  }
+
+  SyncMemoryResources &mMemRes;
+};
+
+
 
 } /* o2::DataDistribution */
 

--- a/src/common/SubTimeFrameDPL.cxx
+++ b/src/common/SubTimeFrameDPL.cxx
@@ -286,7 +286,7 @@ void StfToDplAdapter::sendEosToDpl()
 
   // Send a multiparts
   for (auto lEosCnt = 0U; lEosCnt < mChan.GetNumberOfConnectedPeers(); lEosCnt++) {
-    FairMQParts lCompletedMsg;
+    fair::mq::Parts lCompletedMsg;
     auto lNoFree = [](void*, void*) { /* stack */ };
     lCompletedMsg.AddPart(mChan.NewMessage(lDoneStack.data(), lDoneStack.size(), lNoFree));
     lCompletedMsg.AddPart(mChan.NewMessage());
@@ -452,7 +452,7 @@ std::unique_ptr<SubTimeFrame> DplToStfAdapter::deserialize_impl()
   return lStf;
 }
 
-std::unique_ptr<SubTimeFrame> DplToStfAdapter::deserialize(FairMQParts& pMsgs)
+std::unique_ptr<SubTimeFrame> DplToStfAdapter::deserialize(fair::mq::Parts& pMsgs)
 {
   swap(mMessages, pMsgs.fParts);
   pMsgs.fParts.clear();
@@ -460,7 +460,7 @@ std::unique_ptr<SubTimeFrame> DplToStfAdapter::deserialize(FairMQParts& pMsgs)
   return deserialize_impl();
 }
 
-std::unique_ptr<SubTimeFrame> DplToStfAdapter::deserialize(FairMQChannel& pChan, bool pLogError)
+std::unique_ptr<SubTimeFrame> DplToStfAdapter::deserialize(fair::mq::Channel& pChan, bool pLogError)
 {
   mMessages.clear();
   const std::int64_t lRet = pChan.Receive(mMessages, 500 /* ms */);

--- a/src/common/SubTimeFrameDPL.h
+++ b/src/common/SubTimeFrameDPL.h
@@ -30,7 +30,7 @@ class StfToDplAdapter : public ISubTimeFrameVisitor
 {
  public:
   StfToDplAdapter() = delete;
-  StfToDplAdapter(FairMQChannel& pDplBridgeChan, SyncMemoryResources &pMemRes)
+  StfToDplAdapter(fair::mq::Channel& pDplBridgeChan, SyncMemoryResources &pMemRes)
     : mChan(pDplBridgeChan),
       mMemRes(pMemRes)
   {
@@ -68,8 +68,8 @@ class StfToDplAdapter : public ISubTimeFrameVisitor
   bool mInspectChannel = false;
   bool mReducedHdr = true;
 
-  std::vector<FairMQMessagePtr> mMessages;
-  FairMQChannel& mChan;
+  std::vector<fair::mq::MessagePtr> mMessages;
+  fair::mq::Channel& mChan;
   SyncMemoryResources& mMemRes;
 };
 
@@ -85,15 +85,15 @@ class DplToStfAdapter : public ISubTimeFrameVisitor
   DplToStfAdapter() = default;
   virtual ~DplToStfAdapter() = default;
 
-  std::unique_ptr<SubTimeFrame> deserialize(FairMQChannel& pChan, bool logError = false);
-  std::unique_ptr<SubTimeFrame> deserialize(FairMQParts& pMsgs);
+  std::unique_ptr<SubTimeFrame> deserialize(fair::mq::Channel& pChan, bool logError = false);
+  std::unique_ptr<SubTimeFrame> deserialize(fair::mq::Parts& pMsgs);
 
  protected:
   std::unique_ptr<SubTimeFrame> deserialize_impl();
   void visit(SubTimeFrame& pStf, void*) override;
 
  private:
-  std::vector<FairMQMessagePtr> mMessages;
+  std::vector<fair::mq::MessagePtr> mMessages;
 };
 
 } /* o2::DataDistribution */

--- a/src/common/SubTimeFrameDataModel.h
+++ b/src/common/SubTimeFrameDataModel.h
@@ -186,6 +186,7 @@ struct EquipmentIdentifier {
   friend class SubTimeFrameReadoutBuilder;     \
   friend class SubTimeFrameFileBuilder;        \
   friend class TimeFrameBuilder;               \
+  friend class SubTimeFrameCopyBuilder;        \
   friend class SubTimeFrameFileWriter;         \
   friend class SubTimeFrameFileReader;         \
   friend class StfToDplAdapter;                \

--- a/src/common/SubTimeFrameDataModel.h
+++ b/src/common/SubTimeFrameDataModel.h
@@ -209,11 +209,11 @@ class SubTimeFrame : public IDataModelObject
   struct StfData {
 
     StfData() = delete;
-    StfData(std::unique_ptr<FairMQMessage> &&pHdr, std::unique_ptr<FairMQMessage> &&pData)
+    StfData(fair::mq::MessagePtr &&pHdr, fair::mq::MessagePtr &&pData)
     : mHeader(std::move(pHdr)), mData(std::move(pData)) { }
 
-    std::unique_ptr<FairMQMessage> mHeader;
-    std::unique_ptr<FairMQMessage> mData;
+    fair::mq::MessagePtr mHeader;
+    fair::mq::MessagePtr mData;
 
     inline const o2hdr::DataHeader* getDataHeader() const
     {
@@ -229,14 +229,14 @@ class SubTimeFrame : public IDataModelObject
 
     StfMessage() = delete;
 
-    StfMessage(std::unique_ptr<FairMQMessage> &&pHeader)
+    StfMessage(fair::mq::MessagePtr &&pHeader)
       : mHeader(std::move(pHeader))
     {
       assert(mHeader);
     }
 
-    std::unique_ptr<FairMQMessage> mHeader;
-    std::vector<std::unique_ptr<FairMQMessage>> mDataParts;
+    fair::mq::MessagePtr mHeader;
+    std::vector<fair::mq::MessagePtr> mDataParts;
 
     inline o2hdr::DataHeader* getDataHeaderMutable() {
       if (!mHeader) {
@@ -432,7 +432,7 @@ private:
     return &(lNewMsg.mDataParts);
   }
   // optimized version without vector lookup
-  inline void addStfDataReadout(std::vector<FairMQMessagePtr> *pInVector, FairMQMessagePtr &&pData)
+  inline void addStfDataReadout(std::vector<fair::mq::MessagePtr> *pInVector, fair::mq::MessagePtr &&pData)
   {
     if (!pInVector || pInVector->empty()) {
       EDDLOG("BUG: addStfDataAppend: No header message.");
@@ -460,7 +460,7 @@ private:
 
   // Append a split-payload message
   // e.g. when deserializing a channel or a file
-  inline void addStfDataAppend(std::vector<FairMQMessagePtr> *pInVector, FairMQMessagePtr &&pData)
+  inline void addStfDataAppend(std::vector<fair::mq::MessagePtr> *pInVector, fair::mq::MessagePtr &&pData)
   {
     if (!pInVector || pInVector->empty()) {
       EDDLOG("BUG: addStfDataAppend: No header message");

--- a/src/common/SubTimeFrameFileReader.cxx
+++ b/src/common/SubTimeFrameFileReader.cxx
@@ -61,7 +61,7 @@ void SubTimeFrameFileReader::visit(SubTimeFrame& pStf, void*)
 {
   DataIdentifier lDataId;
   DataHeader::SubSpecificationType lSubSpec;
-  std::vector<FairMQMessagePtr> *lVec = nullptr;
+  std::vector<fair::mq::MessagePtr> *lVec = nullptr;
 
   for (auto& lStfDataPair : mStfData) {
     if (lStfDataPair.mHeader) {

--- a/src/common/SubTimeFrameFileSink.cxx
+++ b/src/common/SubTimeFrameFileSink.cxx
@@ -104,7 +104,7 @@ bpo::options_description SubTimeFrameFileSink::getProgramOptions()
   return lSinkDesc;
 }
 
-bool SubTimeFrameFileSink::loadVerifyConfig(const FairMQProgOptions& pFMQProgOpt)
+bool SubTimeFrameFileSink::loadVerifyConfig(const fair::mq::ProgOptions& pFMQProgOpt)
 {
   mEnabled = pFMQProgOpt.GetValue<bool>(OptionKeyStfSinkEnable);
 

--- a/src/common/SubTimeFrameFileSink.h
+++ b/src/common/SubTimeFrameFileSink.h
@@ -73,7 +73,7 @@ class SubTimeFrameFileSink
     DDDLOG("(Sub)TimeFrame Sink terminated.");
   }
 
-  bool loadVerifyConfig(const FairMQProgOptions& pFMQProgOpt);
+  bool loadVerifyConfig(const fair::mq::ProgOptions& pFMQProgOpt);
   bool makeDirectory();
 
   bool enabled() const { return mEnabled; }

--- a/src/common/SubTimeFrameFileSource.cxx
+++ b/src/common/SubTimeFrameFileSource.cxx
@@ -167,7 +167,7 @@ std::vector<std::string> SubTimeFrameFileSource::getDataFileList() const
   return lFilesVector;
 }
 
-bool SubTimeFrameFileSource::loadVerifyConfig(const FairMQProgOptions& pFMQProgOpt)
+bool SubTimeFrameFileSource::loadVerifyConfig(const fair::mq::ProgOptions& pFMQProgOpt)
 {
   mEnabled = pFMQProgOpt.GetValue<bool>(OptionKeyStfSourceEnable);
 

--- a/src/common/SubTimeFrameFileSource.h
+++ b/src/common/SubTimeFrameFileSource.h
@@ -123,7 +123,7 @@ class SubTimeFrameFileSource
     DDDLOG("(Sub)TimeFrame Source terminated...");
   }
 
-  bool loadVerifyConfig(const FairMQProgOptions& pFMQProgOpt);
+  bool loadVerifyConfig(const fair::mq::ProgOptions& pFMQProgOpt);
   std::vector<std::string> getDataFileList() const;
 
   bool enabled() const { return mEnabled; }

--- a/src/common/SubTimeFrameVisitors.cxx
+++ b/src/common/SubTimeFrameVisitors.cxx
@@ -125,7 +125,7 @@ void IovDeserializer::visit(SubTimeFrame& pStf, void*)
 }
 
 
-std::unique_ptr<SubTimeFrame> IovDeserializer::deserialize(const IovStfHdrMeta &pHdrMeta, std::vector<FairMQMessagePtr>& pDataMsgs)
+std::unique_ptr<SubTimeFrame> IovDeserializer::deserialize(const IovStfHdrMeta &pHdrMeta, std::vector<fair::mq::MessagePtr>& pDataMsgs)
 {
   mIovStfHeader.Clear();
   mIovStfHeader.CopyFrom(pHdrMeta);
@@ -180,7 +180,7 @@ SubTimeFrame::Header IovDeserializer::peek_tf_header(const IovStfHdrMeta &pHdrMe
 }
 
 // copy all messages into the data region, and update the vector
-bool IovDeserializer::copy_to_region(std::vector<FairMQMessagePtr>& pMsgs /* in/out */)
+bool IovDeserializer::copy_to_region(std::vector<fair::mq::MessagePtr>& pMsgs /* in/out */)
 {
   mTfBld.replaceDataMessages(pMsgs);
 

--- a/src/common/SubTimeFrameVisitors.cxx
+++ b/src/common/SubTimeFrameVisitors.cxx
@@ -182,7 +182,7 @@ SubTimeFrame::Header IovDeserializer::peek_tf_header(const IovStfHdrMeta &pHdrMe
 // copy all messages into the data region, and update the vector
 bool IovDeserializer::copy_to_region(std::vector<FairMQMessagePtr>& pMsgs /* in/out */)
 {
-  mTfBld.newDataMessages(pMsgs, pMsgs);
+  mTfBld.replaceDataMessages(pMsgs);
 
   return true;
 }

--- a/src/common/SubTimeFrameVisitors.h
+++ b/src/common/SubTimeFrameVisitors.h
@@ -43,7 +43,7 @@ class IovSerializer : public ISubTimeFrameVisitor
  public:
 
   IovSerializer() = delete;
-  IovSerializer(FairMQChannel& pChan)
+  IovSerializer(fair::mq::Channel& pChan)
     : mChan(pChan)
   {
     mData.reserve(25600);
@@ -61,11 +61,11 @@ class IovSerializer : public ISubTimeFrameVisitor
  private:
   std::atomic_bool mRunning = true;
 
-  std::vector<FairMQMessagePtr> mData;
+  std::vector<fair::mq::MessagePtr> mData;
 
   IovStfHeader mIovHeader;
 
-  FairMQChannel& mChan;
+  fair::mq::Channel& mChan;
 };
 
 
@@ -81,11 +81,11 @@ class IovDeserializer : public ISubTimeFrameVisitor
   : mTfBld(pTfBld) { }
   virtual ~IovDeserializer() = default;
 
-  std::unique_ptr<SubTimeFrame> deserialize(const IovStfHdrMeta &pHdrMeta, std::vector<FairMQMessagePtr>& pDataMsgs);
+  std::unique_ptr<SubTimeFrame> deserialize(const IovStfHdrMeta &pHdrMeta, std::vector<fair::mq::MessagePtr>& pDataMsgs);
 
   SubTimeFrame::Header peek_tf_header(const IovStfHdrMeta &pHdrMeta) const;
 
-  bool copy_to_region(std::vector<FairMQMessagePtr>& pMsgs /* in/out */);
+  bool copy_to_region(std::vector<fair::mq::MessagePtr>& pMsgs /* in/out */);
 
  protected:
   std::unique_ptr<SubTimeFrame> deserialize_impl();
@@ -95,8 +95,8 @@ class IovDeserializer : public ISubTimeFrameVisitor
   // IovStfHeader mIovHeader;
   IovStfHdrMeta mIovStfHeader;
 
-  std::vector<FairMQMessagePtr> mHdrs;
-  std::vector<FairMQMessagePtr> mData;
+  std::vector<fair::mq::MessagePtr> mHdrs;
+  std::vector<fair::mq::MessagePtr> mData;
 
   TimeFrameBuilder &mTfBld;
 };

--- a/src/common/discovery/Config.h
+++ b/src/common/discovery/Config.h
@@ -14,7 +14,7 @@
 #ifndef ALICEO2_DATADIST_CONFIG_H_
 #define ALICEO2_DATADIST_CONFIG_H_
 
-#include <options/FairMQProgOptions.h>
+#include <fairmq/ProgOptions.h>
 #include <tools/Network.h>
 
 #include <boost/program_options/options_description.hpp>
@@ -142,7 +142,7 @@ public:
   }
 
   static
-  std::string getNetworkIfAddressOption(const FairMQProgOptions& pFMQProgOpt)
+  std::string getNetworkIfAddressOption(const fair::mq::ProgOptions& pFMQProgOpt)
   {
     const std::string lIf = pFMQProgOpt.GetValue<std::string>(OptionKeyDiscoveryNetInterface);
     if (lIf.empty()) {
@@ -168,14 +168,14 @@ public:
   }
 
   static
-  std::string getEndpointOption(const FairMQProgOptions& pFMQProgOpt)
+  std::string getEndpointOption(const fair::mq::ProgOptions& pFMQProgOpt)
   {
     auto lOpt = pFMQProgOpt.GetValue<std::string>(OptionKeyDiscoveryEndpoint);
     return lOpt;
   }
 
   static
-  std::string getIdOption(const ProcessType pProcType, const FairMQProgOptions& pFMQProgOpt, const bool pRequired = true)
+  std::string getIdOption(const ProcessType pProcType, const fair::mq::ProgOptions& pFMQProgOpt, const bool pRequired = true)
   {
     // check cmdline first
     {
@@ -209,7 +209,7 @@ public:
   }
 
   static
-  std::optional<std::string> getPartitionOption(const FairMQProgOptions& pFMQProgOpt)
+  std::optional<std::string> getPartitionOption(const fair::mq::ProgOptions& pFMQProgOpt)
   {
     // check ecs value first
     if (!DataDistLogger::sPartitionIdStr.empty()) {


### PR DESCRIPTION
- stfsender: allocate a buffer (32GB) and copy stfs before sending (optional)
- stfsender: enable copying in standalone mode
- adopt to FairMQ API changes
- tfscheduler: optimize incomplete tf bookkeeping
- stfbuilder: decrease size of o2 header region
- ucx: fail from ucp_wait on error
- tfbuilder: monitor token success ratio
- tfscheduler: implement exclusive and shared tokens
- stfsender: fix termination of flp-only run
- tfscheduler: configurable number of tokens per StfSender
- tfbuilder: remove not needed monitoring metric