### PR TITLE
Remove go_package line, ECS will patch as needed

### DIFF
--- a/src/DataDistControl/DataDistControl.proto
+++ b/src/DataDistControl/DataDistControl.proto
@@ -12,7 +12,6 @@
 /// \author Gvozden Nešković, Frankfurt Institute for Advanced Studies and Goethe University Frankfurt
 
 syntax = "proto3";
-option go_package = "protos;ddpb";
 
 // Changelog:
 //      2021-02-08: - Initial version


### PR DESCRIPTION
This became necessary because of changes in the `protoc-gen-go-grpc` tool, which now expects full Go package paths under `go_package`. Rather than adding Go-specific things to the protofile, let's just remove it and let AliECS handle the paths it needs.