### PR TITLE
Adapt to libfmt 9.1.0

### DIFF
--- a/src/common/base/DataDistLogger.h
+++ b/src/common/base/DataDistLogger.h
@@ -105,7 +105,7 @@ public:
       fmt::format_to(fmt::appender(mLogMessage), "<{:s}> ", sThisThreadName);
     }
 
-    do_vformat(format, fmt::make_args_checked<Args...>(format, pArgs...));
+    do_vformat(format, fmt::make_format_args(pArgs...));
   }
 
   template<typename... Args>


### PR DESCRIPTION
@cuveland : This should adapt DD to new libfmt, which has removed make_format_args (https://github.com/fmtlib/fmt/pull/2760/files)