### PR TITLE
use grpc++ instead of grpc++_unsecure

### DIFF
--- a/src/DataDistControl/CMakeLists.txt
+++ b/src/DataDistControl/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(ddcontrol
   PUBLIC
     ppconsul
     protobuf::libprotobuf
-    gRPC::grpc++_unsecure
+    gRPC::grpc++
   PRIVATE
     base
     FairMQ::FairMQ

--- a/src/common/discovery/CMakeLists.txt
+++ b/src/common/discovery/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(discovery
   PUBLIC
     ppconsul
     protobuf::libprotobuf
-    gRPC::grpc++_unsecure
+    gRPC::grpc++
     FairMQ::FairMQ
   PRIVATE
     base


### PR DESCRIPTION
With the recent grpc bump, grpc causes troubles when both grpc and grpc_unsecure are loaded by the same binary. Here, it is the case when StfSender and StfBuilder load the OccLite plugin (which uses grpc). This change fixes both and allows them to be controlled by ECS again. I tested it on a VM setup with FLP suite.

I do not know if it might break DataDistribution in some other context, I hope that anyone reviewing it may know...